### PR TITLE
Add ISymUnmanagedReader5 and ISymUnmanagedEncUpdate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.sln.docstates
 .vs/
+*.VC.db
 
 # Build results
 [Aa]rtifacts/
@@ -21,8 +22,8 @@ x64/
 # NuGet restore semaphore
 build/ToolsetPackages/toolsetpackages.semaphore
 
-# NuGet package
-src/Tools/UploadNugetZip/*.zip
+# NuGet
+nuget.exe
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/SymReader.sln
+++ b/SymReader.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26021.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.DiaSymReader", "src\Microsoft.DiaSymReader\Microsoft.DiaSymReader.shproj", "{F9127F0F-95C8-4576-8081-96E004C1652F}"
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.DiaSymReader", "src\Microsoft.DiaSymReader\Shared\Microsoft.DiaSymReader.shproj", "{F9127F0F-95C8-4576-8081-96E004C1652F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DiaSymReader.NetFX20", "src\Microsoft.DiaSymReader\NetFX20\Microsoft.DiaSymReader.NetFX20.csproj", "{FA2C8969-BD1F-457A-A6E3-CA772135FF73}"
 EndProject
@@ -13,9 +13,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DiaSymReader.Unit
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\Microsoft.DiaSymReader\Microsoft.DiaSymReader.projitems*{316fd2ad-8514-41bd-98d5-61a821f3320e}*SharedItemsImports = 4
-		src\Microsoft.DiaSymReader\Microsoft.DiaSymReader.projitems*{f9127f0f-95c8-4576-8081-96e004c1652f}*SharedItemsImports = 13
-		src\Microsoft.DiaSymReader\Microsoft.DiaSymReader.projitems*{fa2c8969-bd1f-457a-a6e3-ca772135ff73}*SharedItemsImports = 4
+		src\Microsoft.DiaSymReader\Shared\Microsoft.DiaSymReader.projitems*{316fd2ad-8514-41bd-98d5-61a821f3320e}*SharedItemsImports = 4
+		src\Microsoft.DiaSymReader\Shared\Microsoft.DiaSymReader.projitems*{f9127f0f-95c8-4576-8081-96e004c1652f}*SharedItemsImports = 13
+		src\Microsoft.DiaSymReader\Shared\Microsoft.DiaSymReader.projitems*{fa2c8969-bd1f-457a-a6e3-ca772135ff73}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Microsoft.DiaSymReader.Tests/Microsoft.DiaSymReader.UnitTests.csproj
+++ b/src/Microsoft.DiaSymReader.Tests/Microsoft.DiaSymReader.UnitTests.csproj
@@ -31,6 +31,9 @@
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ImportGroup>
     <Import Project="..\..\build\Targets\Imports.targets" />
     <Import Project="..\..\build\Toolset\XunitProjectRunAction.targets" />

--- a/src/Microsoft.DiaSymReader/Shared/Extensions/SymUnmanagedExtensions.Reader.cs
+++ b/src/Microsoft.DiaSymReader/Shared/Extensions/SymUnmanagedExtensions.Reader.cs
@@ -76,6 +76,18 @@ namespace Microsoft.DiaSymReader
             return entryPoint;
         }
 
+        public static ISymUnmanagedDocument GetDocument(this ISymUnmanagedReader reader, string name)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            ISymUnmanagedDocument document;
+            ThrowExceptionForHR(reader.GetDocument(name, default(Guid), default(Guid), default(Guid), out document));
+            return document;
+        }
+
         public static ISymUnmanagedDocument[] GetDocuments(this ISymUnmanagedReader reader)
         {
             if (reader == null)
@@ -100,7 +112,27 @@ namespace Microsoft.DiaSymReader
 
         public static ISymUnmanagedMethod GetMethod(this ISymUnmanagedReader reader, int methodToken)
         {
-            return GetMethodByVersion(reader, methodToken, methodVersion: 1);
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            ISymUnmanagedMethod method;
+            int hr = reader.GetMethod(methodToken, out method);
+            ThrowExceptionForHR(hr);
+
+            if (hr < 0)
+            {
+                // method has no symbol info
+                return null;
+            }
+
+            if (method == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            return method;
         }
 
         public static ISymUnmanagedMethod GetMethodByVersion(this ISymUnmanagedReader reader, int methodToken, int methodVersion)
@@ -110,7 +142,7 @@ namespace Microsoft.DiaSymReader
                 throw new ArgumentNullException(nameof(reader));
             }
 
-            ISymUnmanagedMethod method = null;
+            ISymUnmanagedMethod method;
             int hr = reader.GetMethodByVersion(methodToken, methodVersion, out method);
             ThrowExceptionForHR(hr);
 
@@ -126,6 +158,18 @@ namespace Microsoft.DiaSymReader
             }
 
             return method;
+        }
+
+        public static int GetMethodVersion(this ISymUnmanagedReader reader, ISymUnmanagedMethod method)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            int version;
+            ThrowExceptionForHR(reader.GetMethodVersion(method, out version));
+            return version;
         }
     }
 }

--- a/src/Microsoft.DiaSymReader/Shared/ISymUnmanagedEncUpdate.cs
+++ b/src/Microsoft.DiaSymReader/Shared/ISymUnmanagedEncUpdate.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Microsoft.DiaSymReader
+{
+    [ComImport]
+    [Guid("E502D2DD-8671-4338-8F2A-FC08229628C4")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [ComVisible(false)]
+    public interface ISymUnmanagedEncUpdate
+    {
+        /// <summary>
+        /// Applies EnC edit.
+        /// </summary>
+        [PreserveSig]
+        int UpdateSymbolStore2(
+            IStream stream,
+            [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]SymUnmanagedLineDelta[] lineDeltas,
+            int lineDeltaCount);
+
+        /// <summary>
+        /// Gets the number of local variables of the latest version of the specified method.
+        /// </summary>
+        [PreserveSig]
+        int GetLocalVariableCount(int methodToken, out int count);
+
+        /// <summary>
+        /// Gets local variables of the latest version of the specified method.
+        /// </summary>
+        [PreserveSig]
+        int GetLocalVariables(
+            int methodToken,
+            int bufferLength,
+            [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] ISymUnmanagedVariable[] variables,
+            out int count);
+
+        [PreserveSig]
+        int InitializeForEnc();
+
+        /// <summary>
+        /// Allows updating the line info for a method that has not been recompiled,
+        /// but whose lines have moved independently.  A delta for each statement is allowed.
+        /// </summary>
+        [PreserveSig]
+        int UpdateMethodLines(
+            int methodToken,
+            [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] int[] deltas,
+            int count);
+    }
+}

--- a/src/Microsoft.DiaSymReader/Shared/ISymUnmanagedReader5.cs
+++ b/src/Microsoft.DiaSymReader/Shared/ISymUnmanagedReader5.cs
@@ -7,10 +7,10 @@ using System.Runtime.InteropServices.ComTypes;
 namespace Microsoft.DiaSymReader
 {
     [ComImport]
-    [Guid("E65C58B7-2948-434D-8A6D-481740A00C16")]
+    [Guid("6576c987-7e8d-4298-a6e1-6f9783165f07")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedReader4 : ISymUnmanagedReader3
+    public interface ISymUnmanagedReader5 : ISymUnmanagedReader4
     {
         #region ISymUnmanagedReader methods
 
@@ -169,7 +169,7 @@ namespace Microsoft.DiaSymReader
         /// Checkes whether the id stored in the PDB matches the PDB ID stored in the PE/COFF Debug Directory.
         /// </summary>
         [PreserveSig]
-        int MatchesModule(Guid guid, uint stamp, int age, [MarshalAs(UnmanagedType.Bool)]out bool result);
+        new int MatchesModule(Guid guid, uint stamp, int age, [MarshalAs(UnmanagedType.Bool)]out bool result);
 
         /// <summary>
         /// Returns a pointer to Portable Debug Metadata. Only available for Portable PDBs.
@@ -181,11 +181,18 @@ namespace Microsoft.DiaSymReader
         /// Null if the PDB is not portable.
         /// </param>
         /// <param name="size">Size of the metadata block.</param>
+        /// <returns>
+        /// S_OK if the PDB is portable, S_FALSE if it isn't.
+        /// </returns>
+        /// <remarks>
+        /// If the store was updated via <see cref="UpdateSymbolStore(string, IStream)"/> 
+        /// returns the metadata of the latest update.
+        /// </remarks>
         [PreserveSig]
-        unsafe int GetPortableDebugMetadata(out byte* metadata, out int size);
+        new unsafe int GetPortableDebugMetadata(out byte* metadata, out int size);
 
         /// <summary>
-        /// Returns a pointer to Source Server data stored in the PDB (source link data for Portable PDB or srcsvr section for Windows PDB).
+        /// Returns a pointer to Source Server data stored in the PDB.
         /// </summary>
         /// <param name="data">
         /// A pointer to memory where Source Server data start. The memory is owned by the SymReader and 
@@ -194,15 +201,31 @@ namespace Microsoft.DiaSymReader
         /// Null if the PDB doesn't contain Source Server data.
         /// </param>
         /// <param name="size">Size of the data in bytes.</param>
-        /// <remarks>
-        /// This method is a replacement for <see cref="M:ISymUnmanagedSourceServerModule.GetSourceServerData"/>. 
-        /// The reader doesn't implement <see cref="M:ISymUnmanagedSourceServerModule.GetSourceServerData"/> since 
-        /// the format of the returned data is completely different for Portable PDBs, which the callers wouldn't expect.
-        /// The native diasymreader may implement <see cref="GetSourceServerData(out byte*, out int)"/> by simply calling 
-        /// to <see cref="M:ISymUnmanagedSourceServerModule.GetSourceServerData"/>. 
-        /// </remarks>
+        /// <returns>
+        /// S_OK if the PDB contains Source Server data, S_FALSE if it doesn't.
+        /// </returns>
         [PreserveSig]
-        unsafe int GetSourceServerData(out byte* data, out int size);
+        new unsafe int GetSourceServerData(out byte* data, out int size);
+
+        #endregion
+
+        #region ISymUnmanagedReader5 methods
+
+        /// <summary>
+        /// Returns a pointer to Portable Debug Metadata of the specified version (EnC generation). Only available for Portable PDBs.
+        /// </summary>
+        /// <param name="version">
+        /// EnC 1-based version number. Version 1 corresponds to the baseline.
+        /// </param>
+        /// <param name="metadata">
+        /// A pointer to memory where Portable Debug Metadata start. The memory is owned by the SymReader and 
+        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked. 
+        /// 
+        /// Null if the PDB is not portable.
+        /// </param>
+        /// <param name="size">Size of the metadata block.</param>
+        [PreserveSig]
+        unsafe int GetPortableDebugMetadataByVersion(int version, out byte* metadata, out int size);
 
         #endregion
     }

--- a/src/Microsoft.DiaSymReader/Shared/Microsoft.DiaSymReader.projitems
+++ b/src/Microsoft.DiaSymReader/Shared/Microsoft.DiaSymReader.projitems
@@ -22,10 +22,13 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SymUnmanagedExtensions.Binder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SymUnmanagedSequencePoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SymUnmanagedStreamFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ISymUnmanagedEncUpdate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ISymUnmanagedBinder3.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IMetadataImportProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ISymUnmanagedBinder4.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ISymUnmanagedReader4.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ISymUnmanagedReader5.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SymUnmanagedLineDelta.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SymUnmanagedSearchPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ISymEncUnmanagedMethod.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ISymUnmanagedAsyncMethod.cs" />

--- a/src/Microsoft.DiaSymReader/Shared/SymUnmanagedLineDelta.cs
+++ b/src/Microsoft.DiaSymReader/Shared/SymUnmanagedLineDelta.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+namespace Microsoft.DiaSymReader
+{
+    /// <summary>
+    /// Line deltas allow a compiler to omit functions that have not been modified from
+    /// the pdb stream provided the line information meets the following condition.
+    /// The correct line information can be determined with the old pdb line info and
+    /// one delta for all lines in the function.
+    /// </summary>
+    public struct SymUnmanagedLineDelta
+    {
+        public readonly int MethodToken;
+        public readonly int Delta;
+
+        public SymUnmanagedLineDelta(int methodToken, int delta)
+        {
+            MethodToken = methodToken;
+            Delta = delta;
+        }
+    }
+}


### PR DESCRIPTION
Add interfaces required to support Edit and Continue.
Fixes implementation of GetMethodByVersion helper (it's not equivalent to ```GetMethod(version: 1)```).