### PR TITLE
Updating repo-toolset to 1.0.0-beta-62522-01 for manifest publishing support.

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -8,7 +8,7 @@
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
 
     <!-- Toolset -->
-    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62506-01</RoslynToolsRepoToolsetVersion>
+    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62522-01</RoslynToolsRepoToolsetVersion>
     <DotNetCliVersion>2.0.2</DotNetCliVersion>
 
     <!-- CoreFX -->


### PR DESCRIPTION
FYI. @tmat 