### PR TITLE
Use correct branding for 3.0 preview

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
 
     <!-- This repo version -->
     <VersionPrefix>1.4.0</VersionPrefix>
-    <PreReleaseVersionLabel>beta2</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <SemanticVersioningV1>true</SemanticVersioningV1>
 
     <!-- Opt-in repo features -->


### PR DESCRIPTION
Use the correct branding for 3.0 previews (suffix-less 'preview')