### PR TITLE
Set copyright and package license

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,20 +1,17 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
-  <PropertyGroup>
-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
-  </PropertyGroup>
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>
     <LangVersion>Latest</LangVersion>
+    <NoWarn>$(NoWarn);NU5125</NoWarn>
+
+    <!-- Any code that allows overflows intentionally should be explicitly in an unchecked region. -->
+    <CheckForOverflowUnderflow Condition="'$(Configuration)' == 'Debug'">true</CheckForOverflowUnderflow>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
+  <PropertyGroup Condition="'$(CopyrightMicrosoft)' != ''">
+    <Copyright>$(CopyrightMicrosoft)</Copyright>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Prepares repo for change https://github.com/dotnet/arcade/pull/2003 by setting `Copyright` and `PackageLicenseExpression` properties. These values will be required to be set by each repository once https://github.com/dotnet/arcade/pull/2003 is merged.

In order to not break the current builds this change sets the properties conditionally. This condition can be removed once all repos switch to Arcade that has https://github.com/dotnet/arcade/pull/2003.

@markwilkie
