### PR TITLE
Exclude test project from source-build

### DIFF
--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <IsShipping>false</IsShipping>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />


### PR DESCRIPTION
When building from source, test projects are typically excluded.