### PR TITLE
Exclude PdbTestResources project from source-build

### DIFF
--- a/src/PdbTestResources/PdbTestResources.csproj
+++ b/src/PdbTestResources/PdbTestResources.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <IsShipping>false</IsShipping>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Resources\**\*.cs" />


### PR DESCRIPTION
The PdbTestResources project requires a checked in dll to build.  Since binary files are not included in source-build tarballs and source-build generally does not build test projects, exclude this from source-build.