### PR TITLE
Target .NET Standard 2.0 as well.

### DIFF
--- a/src/Microsoft.DiaSymReader/Microsoft.DiaSymReader.csproj
+++ b/src/Microsoft.DiaSymReader/Microsoft.DiaSymReader.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net20</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net20</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
[It is a best practice](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting) to include a .NET Standard 2.0 target even if a library also targets older .NET Standard versions.