### PR TITLE
ARM64 support

### DIFF
--- a/src/Microsoft.DiaSymReader/SymUnmanagedFactory.cs
+++ b/src/Microsoft.DiaSymReader/SymUnmanagedFactory.cs
@@ -73,32 +73,12 @@ namespace Microsoft.DiaSymReader
 
         private delegate void NativeFactory(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)] out object instance);
 
-        private static readonly Lazy<Func<string, string>> s_lazyGetEnvironmentVariable = new Lazy<Func<string, string>>(() =>
-        {
-            try
-            {
-                foreach (var method in typeof(Environment).GetTypeInfo().GetDeclaredMethods("GetEnvironmentVariable"))
-                {
-                    var parameters = method.GetParameters();
-                    if (parameters.Length == 1 && parameters[0].ParameterType == typeof(string))
-                    {
-                        return (Func<string, string>)method.CreateDelegate(typeof(Func<string, string>));
-                    }
-                }
-            }
-            catch
-            {
-            }
-
-            return null;
-        });
-
         // internal for testing
         internal static string GetEnvironmentVariable(string name)
         {
             try
             {
-                return s_lazyGetEnvironmentVariable.Value?.Invoke(name);
+                return Environment.GetEnvironmentVariable(name);
             }
             catch
             {


### PR DESCRIPTION
This adds ARM64 support to the library. 

In addition to the functional change there are a few cosmetic changes. That was done because I brought this file in sync with the dotnet/roslyn version of the file. Now that the target framework is netstandard2.0 there is no reason for the files to differ anymore. Seemed to make sense to unify them. Can remove the cosmetic changes if you prefer. 

Unfortunately there is no queue in Helix today that is generally available for ARM64 testing. I manually validated this change on an ARM64 machine by dropping it into Roslyn tests that were failing on `Pdb2Xml` and verifying that they passed after this change. 

![image](https://user-images.githubusercontent.com/146967/163241450-00754aa3-db86-4e45-9643-bf4e66549fb4.png)

I used process inspection to double check that it actually did run the ARM64 version of the test runner 

![image](https://user-images.githubusercontent.com/146967/163241511-d47786d4-078f-4341-a3f1-75ee7fc25047.png)
