### PR TITLE
Mark test utility projects

### DIFF
--- a/src/PdbTestResources/PdbTestResources.csproj
+++ b/src/PdbTestResources/PdbTestResources.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <IsShipping>false</IsShipping>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Resources\**\*.cs" />

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
-    <IsShipping>false</IsShipping>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />


### PR DESCRIPTION
Mark test utility projects with `UseIsTestUtilityProject=true` according to the new Arcade feature: https://github.com/dotnet/arcade/commit/6b8e27d1c2922f4b742b999459316b26899d085d

This makes it possible to dynamically skip these projects for certain builds, i.e. source-build or initially in the VMR / vertical build.

cc @mmitche @tmat 