### PR TITLE
Enable publishing in VMR

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <ItemGroup>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishPackages</PublishDependsOnTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_PackagesToPublish Remove="@(_PackagesToPublish)" />
+    <_PackagesToPublish Include="$(ArtifactsPackagesDir)**\*.nupkg" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
+  </ItemGroup>
+
+  <Target Name="_PublishPackages">
+    <ItemGroup>
+      <!-- Do not push .nupkg files from Linux and macOS builds. They'll be packed up separately and signed on Windows.
+           Do not remove if post build sign is true, as we avoid the xplat codesign jobs, and need to have
+           the nupkgs pushed. Do not do this if building from source, since we want the source build intermediate package
+           to be published. Use DotNetBuildRepo as DotNetBuildFromSource is only set in the internal source build,
+           and Build.proj is invoked from the wrapper build. -->
+      <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT' and '$(PostBuildSign)' != 'true' and '$(DotNetBuildRepo)' != 'true'" />
+
+      <ItemsToPushToBlobFeed Include="@(_PackagesToPublish)">
+        <IsShipping>true</IsShipping>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -7,18 +7,12 @@
 
   <ItemGroup>
     <_PackagesToPublish Remove="@(_PackagesToPublish)" />
-    <_PackagesToPublish Include="$(ArtifactsPackagesDir)**\*.nupkg" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
+    <!-- Additional packages needed for source-only VMR build -->
+    <_PackagesToPublish Include="$(ArtifactsPackagesDir)Release\*.nupkg" UploadPathSegment="Runtime" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>
 
   <Target Name="_PublishPackages">
     <ItemGroup>
-      <!-- Do not push .nupkg files from Linux and macOS builds. They'll be packed up separately and signed on Windows.
-           Do not remove if post build sign is true, as we avoid the xplat codesign jobs, and need to have
-           the nupkgs pushed. Do not do this if building from source, since we want the source build intermediate package
-           to be published. Use DotNetBuildRepo as DotNetBuildFromSource is only set in the internal source build,
-           and Build.proj is invoked from the wrapper build. -->
-      <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT' and '$(PostBuildSign)' != 'true' and '$(DotNetBuildRepo)' != 'true'" />
-
       <ItemsToPushToBlobFeed Include="@(_PackagesToPublish)">
         <IsShipping>true</IsShipping>
       </ItemsToPushToBlobFeed>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,24 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <PublishingVersion>3</PublishingVersion>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishPackages</PublishDependsOnTargets>
-  </PropertyGroup>
 
   <ItemGroup>
-    <_PackagesToPublish Remove="@(_PackagesToPublish)" />
     <!--
       Additional packages needed for source-only VMR build - https://github.com/dotnet/source-build/issues/4205
     -->
-    <_PackagesToPublish Include="$(ArtifactsPackagesDir)Release\*.nupkg" UploadPathSegment="Runtime" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+    <ItemsToPushToBlobFeed Include="$(ArtifactsPackagesDir)Release\**\*.nupkg"
+                           IsShipping="true"
+                           UploadPathSegment="Runtime"
+                           Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>
-
-  <Target Name="_PublishPackages">
-    <ItemGroup>
-      <ItemsToPushToBlobFeed Include="@(_PackagesToPublish)">
-        <IsShipping>true</IsShipping>
-      </ItemsToPushToBlobFeed>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -7,7 +7,9 @@
 
   <ItemGroup>
     <_PackagesToPublish Remove="@(_PackagesToPublish)" />
-    <!-- Additional packages needed for source-only VMR build -->
+    <!--
+      Additional packages needed for source-only VMR build - https://github.com/dotnet/source-build/issues/4205
+    -->
     <_PackagesToPublish Include="$(ArtifactsPackagesDir)Release\*.nupkg" UploadPathSegment="Runtime" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4101

Enables publishing in VMR.

This repo creates packages in locations that aren't collected by common publishing infra in arcade. We need to collect them here.