### PR TITLE
Add specific support for the .NET 9 TFM

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- Opt-in/out repo features -->
     <UsingToolPdbConverter>false</UsingToolPdbConverter>

--- a/src/Microsoft.DiaSymReader/Metadata/IMetadataEmit.cs
+++ b/src/Microsoft.DiaSymReader/Metadata/IMetadataEmit.cs
@@ -10,11 +10,11 @@ using System.Security;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("BA3FEE4C-ECB9-4e41-83B7-183FA41CD859")]
     [SuppressUnmanagedCodeSecurity]
-    internal unsafe interface IMetadataEmit
+    [GeneratedWhenPossibleComInterface]
+    internal unsafe partial interface IMetadataEmit
     {
         // SymWriter doesn't use any methods from this interface except for GetTokenFromSig, which is only called when 
         // DefineLocalVariable(2) and DefineConstant(2) don't specify signature token, or the token is nil.

--- a/src/Microsoft.DiaSymReader/Metadata/IMetadataImport.cs
+++ b/src/Microsoft.DiaSymReader/Metadata/IMetadataImport.cs
@@ -5,14 +5,21 @@
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
     [ComVisible(false)]
-    [ComImport]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("7DAC8207-D3AE-4c75-9B67-92801A497D44")]
-    internal unsafe interface IMetadataImport
+#if NET9_0_OR_GREATER
+    [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+#else
+    [ComImport]
+#endif
+    internal unsafe partial interface IMetadataImport
     {
         [PreserveSig]
         void CloseEnum(void* enumHandle);
@@ -26,37 +33,37 @@ namespace Microsoft.DiaSymReader
         [PreserveSig]
         int EnumTypeDefs(
             ref void* enumHandle,
-            [Out]int* typeDefs, 
+            int* typeDefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumInterfaceImpls(
             ref void* enumHandle,
             int typeDef,
-            [Out]int* interfaceImpls,
+            int* interfaceImpls,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumTypeRefs(
             ref void* enumHandle,
-            [Out]int* typeRefs,
+            int* typeRefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int FindTypeDefByName(
-            string name, 
+            string name,
             int enclosingClass,
             out int typeDef); // must be specified
 
         [PreserveSig]
         int GetScopeProps(
-            [Out]char* name, 
-            int bufferLength, 
-            [Out]int* nameLength, 
-            [Out]Guid* mvid);
+            char* name,
+            int bufferLength,
+            int* nameLength,
+            Guid* mvid);
 
         [PreserveSig]
         int GetModuleFromScope(
@@ -65,25 +72,25 @@ namespace Microsoft.DiaSymReader
         [PreserveSig]
         int GetTypeDefProps(
             int typeDef,
-            [Out]char* qualifiedName,
+            char* qualifiedName,
             int qualifiedNameBufferLength,
-            [Out]int* qualifiedNameLength,
-            [Out]TypeAttributes* attributes,
-            [Out]int* baseType);
+            int* qualifiedNameLength,
+            TypeAttributes* attributes,
+            int* baseType);
 
         [PreserveSig]
         int GetInterfaceImplProps(
-            int interfaceImpl, 
-            [Out]int* typeDef,
-            [Out]int* interfaceDefRefSpec);
+            int interfaceImpl,
+            int* typeDef,
+            int* interfaceDefRefSpec);
 
         [PreserveSig]
         int GetTypeRefProps(
             int typeRef,
-            [Out]int* resolutionScope, // ModuleRef or AssemblyRef
-            [Out]char* qualifiedName,
+            int* resolutionScope, // ModuleRef or AssemblyRef
+            char* qualifiedName,
             int qualifiedNameBufferLength,
-            [Out]int* qualifiedNameLength);
+            int* qualifiedNameLength);
 
         /// <summary>
         /// Resolves type reference.
@@ -96,20 +103,20 @@ namespace Microsoft.DiaSymReader
         /// TypeDefs define a type within a scope. TypeRefs refer to type-defs in other scopes
         /// and allow you to import a type from another scope. This function attempts to determine
         /// which type-def a type-ref points to.
-        /// 
+        ///
         /// This resolve (type-ref, this cope) --> (type-def=*ptd, other scope=*ppIScope)
-        /// 
+        ///
         /// However, this resolution requires knowing what modules have been loaded, which is not decided
         /// until runtime via loader / fusion policy. Thus this interface can't possibly be correct since
         /// it doesn't have that knowledge. Furthermore, when inspecting metadata from another process
         /// (such as a debugger inspecting the debuggee's metadata), this API can be truly misleading.
-        /// 
+        ///
         /// This API usage should be avoided.
         /// </remarks>
         [PreserveSig]
         int ResolveTypeRef(
-            int typeRef, 
-            [In] ref Guid scopeInterfaceId,
+            int typeRef,
+            ref Guid scopeInterfaceId,
             [MarshalAs(UnmanagedType.Interface)] out object scope, // must be specified
             out int typeDef); // must be specified
 
@@ -117,100 +124,100 @@ namespace Microsoft.DiaSymReader
         int EnumMembers(
             ref void* enumHandle,
             int typeDef,
-            [Out]int* memberDefs,
+            int* memberDefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumMembersWithName(
-            ref void* enumHandle, 
+            ref void* enumHandle,
             int typeDef,
             string name,
-            [Out]int* memberDefs,
+            int* memberDefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumMethods(
             ref void* enumHandle,
             int typeDef,
-            [Out]int* methodDefs,
+            int* methodDefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumMethodsWithName(
             ref void* enumHandle,
             int typeDef,
             string name,
-            [Out]int* methodDefs,
+            int* methodDefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumFields(
             ref void* enumHandle,
             int typeDef,
-            [Out]int* fieldDefs,
+            int* fieldDefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumFieldsWithName(
             ref void* enumHandle,
             int typeDef,
             string name,
-            [Out]int* fieldDefs,
+            int* fieldDefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumParams(
             ref void* enumHandle,
             int methodDef,
-            [Out]int* paramDefs,
+            int* paramDefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumMemberRefs(
             ref void* enumHandle,
             int parentToken,
-            [Out]int* memberRefs,
+            int* memberRefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumMethodImpls(
-            ref void* enumHandle, 
+            ref void* enumHandle,
             int typeDef,
-            [Out]int* implementationTokens, 
-            [Out]int* declarationTokens,
+            int* implementationTokens,
+            int* declarationTokens,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumPermissionSets(
-            ref void* enumHandle, 
+            ref void* enumHandle,
             int token, // TypeDef, MethodDef or Assembly
             uint action, // DeclarativeSecurityAction
-            [Out]int* declSecurityTokens,
+            int* declSecurityTokens,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int FindMember(
             int typeDef,
             string name,
-            [In]byte* signature, 
+            byte* signature,
             int signatureLength,
             out int memberDef);
 
         [PreserveSig]
         int FindMethod(
-            int typeDef, 
+            int typeDef,
             string name,
-            [In]byte* signature, 
+            byte* signature,
             int signatureLength,
             out int methodDef);
 
@@ -218,289 +225,290 @@ namespace Microsoft.DiaSymReader
         int FindField(
             int typeDef,
             string name,
-            [In]byte* signature,
+            byte* signature,
             int signatureLength,
             out int fieldDef);
 
         [PreserveSig]
         int FindMemberRef(
-            int typeDef, 
+            int typeDef,
             string name,
-            [In]byte* signature,
+            byte* signature,
             int signatureLength,
             out int memberRef);
 
         [PreserveSig]
         int GetMethodProps(
            int methodDef,
-           [Out]int* declaringTypeDef,
-           [Out]char* name, 
+           int* declaringTypeDef,
+           char* name,
            int nameBufferLength,
-           [Out]int* nameLength,
-           [Out]MethodAttributes* attributes,
-           [Out]byte** signature, // returns pointer to signature blob
-           [Out]int* signatureLength,
-           [Out]int* relativeVirtualAddress,
-           [Out]MethodImplAttributes* implAttributes);
+           int* nameLength,
+           MethodAttributes* attributes,
+           byte** signature, // returns pointer to signature blob
+           int* signatureLength,
+           int* relativeVirtualAddress,
+           MethodImplAttributes* implAttributes);
 
         [PreserveSig]
         int GetMemberRefProps(
             int memberRef,
-            [Out]int* declaringType, // TypeDef or TypeRef
-            [Out]char* name,
+            int* declaringType, // TypeDef or TypeRef
+            char* name,
             int nameBufferLength,
-            [Out]int* nameLength,
-            [Out]byte** signature, // returns pointer to signature blob
-            [Out]int* signatureLength);
+            int* nameLength,
+            byte** signature, // returns pointer to signature blob
+            int* signatureLength);
 
         [PreserveSig]
         int EnumProperties(
            ref void* enumHandle,
            int typeDef,
-           [Out]int* properties,
+           int* properties,
            int bufferLength,
-           [Out]int* count);
+           int* count);
 
         [PreserveSig]
         uint EnumEvents(
            ref void* enumHandle,
            int typeDef,
-           [Out]int* events,
+           int* events,
            int bufferLength,
-           [Out]int* count);
+           int* count);
 
         [PreserveSig]
         int GetEventProps(
-            int @event, 
-            [Out]int* declaringTypeDef,
-            [Out]char* name, 
-            int nameBufferLength, 
-            [Out]int* nameLength, 
-            [Out]int* attributes,
-            [Out]int* eventType,
-            [Out]int* adderMethodDef, 
-            [Out]int* removerMethodDef,
-            [Out]int* raiserMethodDef, 
-            [Out]int* otherMethodDefs, 
+            int @event,
+            int* declaringTypeDef,
+            char* name,
+            int nameBufferLength,
+            int* nameLength,
+            int* attributes,
+            int* eventType,
+            int* adderMethodDef,
+            int* removerMethodDef,
+            int* raiserMethodDef,
+            int* otherMethodDefs,
             int otherMethodDefBufferLength,
-            [Out]int* methodMethodDefsLength);
+            int* methodMethodDefsLength);
 
         [PreserveSig]
         int EnumMethodSemantics(
             ref void* enumHandle,
             int methodDef,
-            [Out]int* eventsAndProperties,
+            int* eventsAndProperties,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int GetMethodSemantics(
-            int methodDef, 
+            int methodDef,
             int eventOrProperty,
-            [Out]int* semantics);
+            int* semantics);
 
         [PreserveSig]
         int GetClassLayout(
-            int typeDef, 
-            [Out]int* packSize,  // 1, 2, 4, 8, or 16
-            [Out]MetadataImportFieldOffset* fieldOffsets,
+            int typeDef,
+            int* packSize,  // 1, 2, 4, 8, or 16
+            MetadataImportFieldOffset* fieldOffsets,
             int bufferLength,
-            [Out]int* count,
-            [Out]int* typeSize);
+            int* count,
+            int* typeSize);
 
         [PreserveSig]
         int GetFieldMarshal(
             int fieldDef,
-            [Out]byte** nativeTypeSignature, // returns pointer to signature blob
-            [Out]int* nativeTypeSignatureLength);
+            byte** nativeTypeSignature, // returns pointer to signature blob
+            int* nativeTypeSignatureLength);
 
         [PreserveSig]
         int GetRVA(
-            int methodDef, 
-            [Out]int* relativeVirtualAddress,
-            [Out]int* implAttributes);
+            int methodDef,
+            int* relativeVirtualAddress,
+            int* implAttributes);
 
         [PreserveSig]
         int GetPermissionSetProps(
             int declSecurity,
-            [Out]uint* action,
-            [Out]byte** permissionBlob, // returns pointer to permission blob
-            [Out]int* permissionBlobLength);
+            uint* action,
+            byte** permissionBlob, // returns pointer to permission blob
+            int* permissionBlobLength);
 
         [PreserveSig]
         int GetSigFromToken(
             int standaloneSignature,
-            [Out]byte** signature, // returns pointer to signature blob
-            [Out]int* signatureLength);
+            byte** signature, // returns pointer to signature blob
+            int* signatureLength);
 
         [PreserveSig]
         int GetModuleRefProps(
-            int moduleRef, 
-            [Out]char* name,
+            int moduleRef,
+            char* name,
             int nameBufferLength,
-            [Out]int* nameLength);
+            int* nameLength);
 
         [PreserveSig]
         int EnumModuleRefs(
             ref void* enumHandle,
-            [Out]int* moduleRefs,
+            int* moduleRefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int GetTypeSpecFromToken(
-            int typeSpec, 
-            [Out]byte** signature, // returns pointer to signature blob
-            [Out]int* signatureLength);
+            int typeSpec,
+            byte** signature, // returns pointer to signature blob
+            int* signatureLength);
 
         [PreserveSig]
         int GetNameFromToken(
             int token,
-            [Out]byte* nameUTF8); // name on the #String heap
+            byte* nameUTF8); // name on the #String heap
 
         [PreserveSig]
         int EnumUnresolvedMethods(
             ref void* enumHandle,
-            [Out]int* methodDefs,
+            int* methodDefs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int GetUserString(
             int userStringToken,
-            [Out]char* buffer, 
+            char* buffer,
             int bufferLength,
-            [Out]int* length);
+            int* length);
 
         [PreserveSig]
         int GetPinvokeMap(
             int memberDef,  // FieldDef, MethodDef
-            [Out]int* attributes, 
-            [Out]char* importName,
-            int importNameBufferLength, 
-            [Out]int* importNameLength,
-            [Out]int* moduleRef);
+            int* attributes,
+            char* importName,
+            int importNameBufferLength,
+            int* importNameLength,
+            int* moduleRef);
 
         [PreserveSig]
         int EnumSignatures(
             ref void* enumHandle,
-            [Out]int* signatureTokens,
+            int* signatureTokens,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumTypeSpecs(
             ref void* enumHandle,
-            [Out]int* typeSpecs,
+            int* typeSpecs,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int EnumUserStrings(
             ref void* enumHandle,
-            [Out]int* userStrings,
+            int* userStrings,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int GetParamForMethodIndex(
             int methodDef,
-            int sequenceNumber, 
+            int sequenceNumber,
             out int parameterToken); // must be specified
 
         [PreserveSig]
         int EnumCustomAttributes(
             ref void* enumHandle,
-            int parent, 
+            int parent,
             int attributeType,
-            [Out]int* customAttributes,
+            int* customAttributes,
             int bufferLength,
-            [Out]int* count);
+            int* count);
 
         [PreserveSig]
         int GetCustomAttributeProps(
             int customAttribute,
-            [Out]int* parent, 
-            [Out]int* constructor,  // MethodDef, MethodRef
-            [Out]byte** value, // returns pointer to a value blob
-            [Out]int* valueLength);
+            int* parent,
+            int* constructor,  // MethodDef, MethodRef
+            byte** value, // returns pointer to a value blob
+            int* valueLength);
 
         [PreserveSig]
         int FindTypeRef(
-            int resolutionScope, 
+            int resolutionScope,
             string name,
             out int typeRef); // must be specified
 
         [PreserveSig]
         int GetMemberProps(
             int member, // Field or Property
-            [Out]int* declaringTypeDef,
-            [Out]char* name, 
-            int nameBufferLength, 
-            [Out]int* nameLength, 
-            [Out]int* attributes,
-            [Out]byte** signature, // returns pointer to signature blob 
-            [Out]int* signatureLength,
-            [Out]int* relativeVirtualAddress,
-            [Out]int* implAttributes,
-            [Out]int* constantType, 
-            [Out]byte** constantValue, // returns pointer to constant value blob
-            [Out]int* constantValueLength);
+            int* declaringTypeDef,
+            char* name,
+            int nameBufferLength,
+            int* nameLength,
+            int* attributes,
+            byte** signature, // returns pointer to signature blob
+            int* signatureLength,
+            int* relativeVirtualAddress,
+            int* implAttributes,
+            int* constantType,
+            byte** constantValue, // returns pointer to constant value blob
+            int* constantValueLength);
 
         [PreserveSig]
         int GetFieldProps(
             int fieldDef,
-            [Out]int* declaringTypeDef,
-            [Out]char* name,
+            int* declaringTypeDef,
+            char* name,
             int nameBufferLength,
-            [Out]int* nameLength,
-            [Out]int* attributes,
-            [Out]byte** signature, // returns pointer to signature blob 
-            [Out]int* signatureLength,
-            [Out]int* constantType,
-            [Out]byte** constantValue, // returns pointer to constant value blob
-            [Out]int* constantValueLength);
+            int* nameLength,
+            int* attributes,
+            byte** signature, // returns pointer to signature blob
+            int* signatureLength,
+            int* constantType,
+            byte** constantValue, // returns pointer to constant value blob
+            int* constantValueLength);
 
         [PreserveSig]
         int GetPropertyProps(
             int propertyDef,
-            [Out]int* declaringTypeDef,
-            [Out]char* name,
+            int* declaringTypeDef,
+            char* name,
             int nameBufferLength,
-            [Out]int* nameLength,
-            [Out]int* attributes,
-            [Out]byte** signature, // returns pointer to signature blob 
-            [Out]int* signatureLength,
-            [Out]int* constantType,
-            [Out]byte** constantValue, // returns pointer to constant value blob
-            [Out]int* constantValueLength,
-            [Out]int* setterMethodDef,
-            [Out]int* getterMethodDef,
-            [Out]int* outerMethodDefs,
+            int* nameLength,
+            int* attributes,
+            byte** signature, // returns pointer to signature blob
+            int* signatureLength,
+            int* constantType,
+            byte** constantValue, // returns pointer to constant value blob
+            int* constantValueLength,
+            int* setterMethodDef,
+            int* getterMethodDef,
+            int* outerMethodDefs,
             int outerMethodDefsBufferLength,
-            [Out]int* otherMethodDefCount);
+            int* otherMethodDefCount);
 
         [PreserveSig]
         int GetParamProps(
-            int parameter, 
-            [Out]int* declaringMethodDef, 
-            [Out]int* sequenceNumber,
-            [Out]char* name,
-            int nameBufferLength, 
-            [Out]int* nameLength,
-            [Out]int* attributes,
-            [Out]int* constantType,
-            [Out]byte** constantValue, // returns pointer to constant value blob
-            [Out]int* constantValueLength);
+            int parameter,
+            int* declaringMethodDef,
+            int* sequenceNumber,
+            char* name,
+            int nameBufferLength,
+            int* nameLength,
+            int* attributes,
+            int* constantType,
+            byte** constantValue, // returns pointer to constant value blob
+            int* constantValueLength);
 
         [PreserveSig]
         int GetCustomAttributeByName(
-            int parent, 
-            string name, 
-            [Out]byte** value, // returns pointer to a value blob
-            [Out]int* valueLength);
+            int parent,
+            string name,
+            byte** value, // returns pointer to a value blob
+            int* valueLength);
 
         [PreserveSig]
+        [return: MarshalAs(UnmanagedType.Bool)]
         bool IsValidToken(int token);
 
         [PreserveSig]
@@ -510,13 +518,13 @@ namespace Microsoft.DiaSymReader
 
         [PreserveSig]
         int GetNativeCallConvFromSig(
-            [In]byte* signature,
+            byte* signature,
             int signatureLength,
-            [Out]int* callingConvention);
+            int* callingConvention);
 
         [PreserveSig]
         int IsGlobal(
             int token,
-            [Out]bool value); 
+            [MarshalAs(UnmanagedType.Bool)] bool value);
     }
 }

--- a/src/Microsoft.DiaSymReader/Metadata/IMetadataImportProvider.cs
+++ b/src/Microsoft.DiaSymReader/Metadata/IMetadataImportProvider.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("EDF3A293-A10D-4F4A-A609-38D5EDE35F89")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface IMetadataImportProvider
+    [GeneratedWhenPossibleComInterface]
+    public partial interface IMetadataImportProvider
     {
         /// <summary>
         /// Gets an instance of IMetadataImport.

--- a/src/Microsoft.DiaSymReader/Metadata/MetadataAdapterBase.cs
+++ b/src/Microsoft.DiaSymReader/Metadata/MetadataAdapterBase.cs
@@ -6,9 +6,16 @@ using System;
 using System.Runtime.InteropServices;
 using System.Reflection;
 
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
+
 namespace Microsoft.DiaSymReader
 {
-    internal unsafe class MetadataAdapterBase : IMetadataImport, IMetadataEmit
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    internal unsafe partial class MetadataAdapterBase : IMetadataImport, IMetadataEmit
     {
         public virtual int GetTokenFromSig(byte* voidPointerSig, int byteCountSig)
             => throw new NotImplementedException();

--- a/src/Microsoft.DiaSymReader/Metadata/SymReaderMetadataAdapter.cs
+++ b/src/Microsoft.DiaSymReader/Metadata/SymReaderMetadataAdapter.cs
@@ -5,13 +5,19 @@
 using System.Runtime.InteropServices;
 using System.Reflection;
 using System.Diagnostics;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
     /// <summary>
     /// Minimal implementation of IMetadataImport that implements APIs used by SymReader.
     /// </summary>
-    internal unsafe sealed class SymReaderMetadataAdapter : MetadataAdapterBase
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    internal unsafe sealed partial class SymReaderMetadataAdapter : MetadataAdapterBase
     {
         private readonly ISymReaderMetadataProvider _metadataProvider;
 

--- a/src/Microsoft.DiaSymReader/Metadata/SymWriterMetadataAdapter.cs
+++ b/src/Microsoft.DiaSymReader/Metadata/SymWriterMetadataAdapter.cs
@@ -6,13 +6,19 @@ using System;
 using System.Runtime.InteropServices;
 using System.Reflection;
 using System.Diagnostics;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
     /// <summary>
     /// Minimal implementation of IMetadataImport that implements APIs used by SymReader and SymWriter.
     /// </summary>
-    internal unsafe sealed class SymWriterMetadataAdapter : MetadataAdapterBase
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    internal unsafe sealed partial class SymWriterMetadataAdapter : MetadataAdapterBase
     {
         private readonly ISymWriterMetadataProvider _metadataProvider;
 

--- a/src/Microsoft.DiaSymReader/Microsoft.DiaSymReader.csproj
+++ b/src/Microsoft.DiaSymReader/Microsoft.DiaSymReader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.DiaSymReader/Reader/ISymEncUnmanagedMethod.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymEncUnmanagedMethod.cs
@@ -8,11 +8,11 @@ using System.Text;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("85E891DA-A631-4c76-ACA2-A44A39C46B8C")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymEncUnmanagedMethod
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymEncUnmanagedMethod
     {
         /// <summary>
         /// Get the file name for the line associated with offset dwOffset.

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedAsyncMethod.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedAsyncMethod.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("B20D55B3-532E-4906-87E7-25BD5734ABD2")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedAsyncMethod
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedAsyncMethod
     {
         [PreserveSig]
         int IsAsyncMethod([MarshalAs(UnmanagedType.Bool)]out bool value);

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("AA544D42-28CB-11d3-BD22-0000F80849BD")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedBinder
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedBinder
     {
         /// <summary>
         /// Given a metadata interface and a file name, returns a new instance of <see cref="ISymUnmanagedReader"/> 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder2.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder2.cs
@@ -7,12 +7,13 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("ACCEE350-89AF-4ccb-8B40-1C2C4C6F9434")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedBinder2 : ISymUnmanagedBinder
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedBinder2 : ISymUnmanagedBinder
     {
+#if NETSTANDARD2_0
         #region ISymUnmanagedBinder methods
 
         /// <summary>
@@ -47,6 +48,7 @@ namespace Microsoft.DiaSymReader
             [MarshalAs(UnmanagedType.Interface)]out ISymUnmanagedReader reader);
 
         #endregion
+#endif
 
         /// <summary>
         /// Given a metadata interface and a file name, returns the 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder2.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder2.cs
@@ -13,6 +13,8 @@ namespace Microsoft.DiaSymReader
     [GeneratedWhenPossibleComInterface]
     public partial interface ISymUnmanagedBinder2 : ISymUnmanagedBinder
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
         #region ISymUnmanagedBinder methods
 
@@ -51,7 +53,7 @@ namespace Microsoft.DiaSymReader
 #endif
 
         /// <summary>
-        /// Given a metadata interface and a file name, returns the 
+        /// Given a metadata interface and a file name, returns the
         /// <see cref="ISymUnmanagedReader"/> interface that will read the debugging symbols associated
         /// with the module.
         /// </summary>

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder3.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder3.cs
@@ -7,12 +7,13 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("28AD3D43-B601-4d26-8A1B-25F9165AF9D7")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedBinder3 : ISymUnmanagedBinder2
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedBinder3 : ISymUnmanagedBinder2
     {
+#if NETSTANDARD2_0
         #region ISymUnmanagedBinder methods
 
         /// <summary>
@@ -74,14 +75,15 @@ namespace Microsoft.DiaSymReader
             [MarshalAs(UnmanagedType.Interface)]out ISymUnmanagedReader reader);
 
         #endregion
+#endif
 
         [PreserveSig]
         int GetReaderFromCallback(
-            [In, MarshalAs(UnmanagedType.Interface)] object metadataImporter,
+            [MarshalAs(UnmanagedType.Interface)] object metadataImporter,
             [MarshalAs(UnmanagedType.LPWStr)]string fileName,
             [MarshalAs(UnmanagedType.LPWStr)]string searchPath,
             SymUnmanagedSearchPolicy searchPolicy,
-            [In, MarshalAs(UnmanagedType.Interface)] object callback,
+            [MarshalAs(UnmanagedType.Interface)] object callback,
             [MarshalAs(UnmanagedType.Interface)]out ISymUnmanagedReader reader);
     }
 }

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder3.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder3.cs
@@ -13,6 +13,8 @@ namespace Microsoft.DiaSymReader
     [GeneratedWhenPossibleComInterface]
     public partial interface ISymUnmanagedBinder3 : ISymUnmanagedBinder2
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
         #region ISymUnmanagedBinder methods
 
@@ -52,7 +54,7 @@ namespace Microsoft.DiaSymReader
         #region ISymUnmanagedBinder2 methods
 
         /// <summary>
-        /// Given a metadata interface and a file name, returns the 
+        /// Given a metadata interface and a file name, returns the
         /// <see cref="ISymUnmanagedReader"/> interface that will read the debugging symbols associated
         /// with the module.
         /// </summary>

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder4.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder4.cs
@@ -13,6 +13,8 @@ namespace Microsoft.DiaSymReader
     [GeneratedWhenPossibleComInterface]
     public partial interface ISymUnmanagedBinder4 : ISymUnmanagedBinder3
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
         #region ISymUnmanagedBinder methods
 
@@ -52,7 +54,7 @@ namespace Microsoft.DiaSymReader
         #region ISymUnmanagedBinder2 methods
 
         /// <summary>
-        /// Given a metadata interface and a file name, returns the 
+        /// Given a metadata interface and a file name, returns the
         /// <see cref="ISymUnmanagedReader"/> interface that will read the debugging symbols associated
         /// with the module.
         /// </summary>

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder4.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedBinder4.cs
@@ -7,12 +7,13 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("F1DC5735-F877-48C9-BBE7-2A5486E84D7C")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedBinder4 : ISymUnmanagedBinder3
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedBinder4 : ISymUnmanagedBinder3
     {
+#if NETSTANDARD2_0
         #region ISymUnmanagedBinder methods
 
         /// <summary>
@@ -87,6 +88,7 @@ namespace Microsoft.DiaSymReader
             [MarshalAs(UnmanagedType.Interface)]out ISymUnmanagedReader reader);
 
         #endregion
+#endif
 
         #region ISymUnmanagedBinder4 methods
 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedConstant.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedConstant.cs
@@ -8,11 +8,11 @@ using System.Text;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("48B25ED8-5BAD-41bc-9CEE-CD62FABC74E9")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedConstant
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedConstant
     {
         [PreserveSig]
         int GetName(
@@ -21,7 +21,7 @@ namespace Microsoft.DiaSymReader
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] char[] name);
 
         [PreserveSig]
-        int GetValue(out object value);
+        int GetValue([MarshalAs(UnmanagedType.Struct)] out object value);
 
         [PreserveSig]
         int GetSignature(

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedDispose.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedDispose.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("969708D2-05E5-4861-A3B0-96E473CDF63F")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedDispose
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedDispose
     {
         [PreserveSig]
         int Destroy();

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedDocument.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedDocument.cs
@@ -8,11 +8,11 @@ using System.Text;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
-    [ComVisible(false)]
     [Guid("40DE4037-7C81-3E1E-B022-AE1ABFF2CA08")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface ISymUnmanagedDocument
+    [ComVisible(false)]
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedDocument
     {
         [PreserveSig]
         int GetUrl(

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedEncUpdate.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedEncUpdate.cs
@@ -4,22 +4,27 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("E502D2DD-8671-4338-8F2A-FC08229628C4")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedEncUpdate
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedEncUpdate
     {
         /// <summary>
         /// Applies EnC edit.
         /// </summary>
         [PreserveSig]
         int UpdateSymbolStore2(
-            IStream stream,
+#if NET9_0_OR_GREATER
+            [MarshalUsing(typeof(ComStreamWrapper.Marshaller))]
+#endif
+            System.Runtime.InteropServices.ComTypes.IStream stream,
             [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]SymUnmanagedLineDelta[] lineDeltas,
             int lineDeltaCount);
 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedMethod.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedMethod.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("B62B923C-B500-3158-A543-24F307A8B7E1")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedMethod
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedMethod
     {
         [PreserveSig]
         int GetToken(out int methodToken);
@@ -70,7 +70,7 @@ namespace Microsoft.DiaSymReader
         /// <returns>HResult</returns>
         [PreserveSig]
         int GetSourceStartEnd(
-            ISymUnmanagedDocument[] documents,
+            [In, Out, MarshalAs(UnmanagedType.LPArray)] ISymUnmanagedDocument[] documents,
             [In, Out, MarshalAs(UnmanagedType.LPArray)] int[] lines,
             [In, Out, MarshalAs(UnmanagedType.LPArray)] int[] columns,
             [MarshalAs(UnmanagedType.Bool)]out bool defined);

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedMethod2.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedMethod2.cs
@@ -13,6 +13,8 @@ namespace Microsoft.DiaSymReader
     [GeneratedWhenPossibleComInterface]
     public partial interface ISymUnmanagedMethod2 : ISymUnmanagedMethod
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
         #region ISymUnmanagedMethod methods
 
@@ -100,7 +102,7 @@ namespace Microsoft.DiaSymReader
         /// <param name="localSignatureToken">Local signature token (StandAloneSig), or 0 if the method doesn't have any local variables.</param>
         /// <returns>
         /// S_OK if the method has a local signature,
-        /// S_FALSE if the method doesn't have a local signature, 
+        /// S_FALSE if the method doesn't have a local signature,
         /// E_* if an error occurs while reading the signature.
         /// </returns>
         [PreserveSig]

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedMethod2.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedMethod2.cs
@@ -7,12 +7,13 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("5da320c8-9c2c-4e5a-b823-027e0677b359")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedMethod2 : ISymUnmanagedMethod
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedMethod2 : ISymUnmanagedMethod
     {
+#if NETSTANDARD2_0
         #region ISymUnmanagedMethod methods
 
         [PreserveSig]
@@ -89,6 +90,7 @@ namespace Microsoft.DiaSymReader
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] int[] endColumns);
 
         #endregion
+#endif
 
         #region ISymUnmanagedMethod2 methods
 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedNamespace.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedNamespace.cs
@@ -8,11 +8,11 @@ using System.Text;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("0DFF7289-54F8-11d3-BD28-0000F80849BD")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedNamespace
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedNamespace
     {
         [PreserveSig]
         int GetName(

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader.cs
@@ -4,15 +4,17 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("B4CE6286-2A6B-3712-A3B7-1EE1DAD467B5")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedReader
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedReader
     {
         [PreserveSig]
         int GetDocument(
@@ -79,13 +81,24 @@ namespace Microsoft.DiaSymReader
             [MarshalAs(UnmanagedType.Interface)] object metadataImporter,
             [MarshalAs(UnmanagedType.LPWStr)] string fileName,
             [MarshalAs(UnmanagedType.LPWStr)] string searchPath,
-            IStream stream);
+#if NET9_0_OR_GREATER
+            [MarshalUsing(typeof(ComStreamWrapper.Marshaller))]
+#endif
+            System.Runtime.InteropServices.ComTypes.IStream stream);
 
         [PreserveSig]
-        int UpdateSymbolStore([MarshalAs(UnmanagedType.LPWStr)] string fileName, IStream stream);
+        int UpdateSymbolStore([MarshalAs(UnmanagedType.LPWStr)] string fileName,
+#if NET9_0_OR_GREATER
+            [MarshalUsing(typeof(ComStreamWrapper.Marshaller))]
+#endif
+            System.Runtime.InteropServices.ComTypes.IStream stream);
 
         [PreserveSig]
-        int ReplaceSymbolStore([MarshalAs(UnmanagedType.LPWStr)] string fileName, IStream stream);
+        int ReplaceSymbolStore([MarshalAs(UnmanagedType.LPWStr)] string fileName,
+#if NET9_0_OR_GREATER
+            [MarshalUsing(typeof(ComStreamWrapper.Marshaller))]
+#endif
+            System.Runtime.InteropServices.ComTypes.IStream stream);
 
         [PreserveSig]
         int GetSymbolStoreFileName(

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader2.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader2.cs
@@ -4,16 +4,20 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
+
+#if NETSTANDARD2_0
+using IStream = System.Runtime.InteropServices.ComTypes.IStream;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("A09E53B2-2A57-4cca-8F63-B84F7C35D4AA")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedReader2 : ISymUnmanagedReader
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedReader2 : ISymUnmanagedReader
     {
+#if NETSTANDARD2_0
         #region ISymUnmanagedReader methods
 
         [PreserveSig]
@@ -111,6 +115,7 @@ namespace Microsoft.DiaSymReader
         new int GetMethodVersion(ISymUnmanagedMethod method, out int version);
 
         #endregion
+#endif
 
         #region ISymUnmanagedReader2 methods
 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader2.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader2.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DiaSymReader
     [GeneratedWhenPossibleComInterface]
     public partial interface ISymUnmanagedReader2 : ISymUnmanagedReader
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
         #region ISymUnmanagedReader methods
 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader3.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader3.cs
@@ -4,16 +4,20 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
+
+#if NETSTANDARD2_0
+using IStream = System.Runtime.InteropServices.ComTypes.IStream;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("6151CAD9-E1EE-437A-A808-F64838C0D046")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedReader3 : ISymUnmanagedReader2
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedReader3 : ISymUnmanagedReader2
     {
+#if NETSTANDARD2_0
         #region ISymUnmanagedReader methods
 
         [PreserveSig]
@@ -136,11 +140,12 @@ namespace Microsoft.DiaSymReader
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] ISymUnmanagedMethod[] methods);
 
         #endregion
+#endif
 
         #region ISymUnmanagedReader3 methods
 
         /// <summary>
-        /// Gets a custom debug information based upon its name and an EnC 1-based version number. 
+        /// Gets a custom debug information based upon its name and an EnC 1-based version number.
         /// </summary>
         [PreserveSig]
         int GetSymAttributeByVersion(
@@ -152,7 +157,7 @@ namespace Microsoft.DiaSymReader
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] customDebugInformation);
 
         /// <summary>
-        /// Gets a custom debug information based upon its name and an EnC 1-based version number. 
+        /// Gets a custom debug information based upon its name and an EnC 1-based version number.
         /// </summary>
         [PreserveSig]
         int GetSymAttributeByVersionPreRemap(
@@ -163,6 +168,6 @@ namespace Microsoft.DiaSymReader
             out int count,
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] customDebugInformation);
 
-        #endregion  
+        #endregion
     }
 }

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader3.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader3.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DiaSymReader
     [GeneratedWhenPossibleComInterface]
     public partial interface ISymUnmanagedReader3 : ISymUnmanagedReader2
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
         #region ISymUnmanagedReader methods
 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader4.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader4.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DiaSymReader
     [GeneratedWhenPossibleComInterface]
     public partial interface ISymUnmanagedReader4 : ISymUnmanagedReader3
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
         #region ISymUnmanagedReader methods
 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader4.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader4.cs
@@ -4,16 +4,20 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
+
+#if NETSTANDARD2_0
+using IStream = System.Runtime.InteropServices.ComTypes.IStream;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("E65C58B7-2948-434D-8A6D-481740A00C16")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedReader4 : ISymUnmanagedReader3
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedReader4 : ISymUnmanagedReader3
     {
+#if NETSTANDARD2_0
         #region ISymUnmanagedReader methods
 
         [PreserveSig]
@@ -140,7 +144,7 @@ namespace Microsoft.DiaSymReader
         #region ISymUnmanagedReader3 methods
 
         /// <summary>
-        /// Gets a custom debug information based upon its name and an EnC 1-based version number. 
+        /// Gets a custom debug information based upon its name and an EnC 1-based version number.
         /// </summary>
         [PreserveSig]
         new int GetSymAttributeByVersion(
@@ -152,7 +156,7 @@ namespace Microsoft.DiaSymReader
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] customDebugInformation);
 
         /// <summary>
-        /// Gets a custom debug information based upon its name and an EnC 1-based version number. 
+        /// Gets a custom debug information based upon its name and an EnC 1-based version number.
         /// </summary>
         [PreserveSig]
         new int GetSymAttributeByVersionPreRemap(
@@ -164,6 +168,7 @@ namespace Microsoft.DiaSymReader
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] customDebugInformation);
 
         #endregion
+#endif
 
         #region ISymUnmanagedReader4 methods
 
@@ -177,9 +182,9 @@ namespace Microsoft.DiaSymReader
         /// Returns a pointer to Portable Debug Metadata. Only available for Portable PDBs.
         /// </summary>
         /// <param name="metadata">
-        /// A pointer to memory where Portable Debug Metadata start. The memory is owned by the SymReader and 
-        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked. 
-        /// 
+        /// A pointer to memory where Portable Debug Metadata start. The memory is owned by the SymReader and
+        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked.
+        ///
         /// Null if the PDB is not portable.
         /// </param>
         /// <param name="size">Size of the metadata block.</param>
@@ -190,18 +195,18 @@ namespace Microsoft.DiaSymReader
         /// Returns a pointer to Source Server data stored in the PDB (source link data for Portable PDB or srcsvr section for Windows PDB).
         /// </summary>
         /// <param name="data">
-        /// A pointer to memory where Source Server data start. The memory is owned by the SymReader and 
-        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked. 
-        /// 
+        /// A pointer to memory where Source Server data start. The memory is owned by the SymReader and
+        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked.
+        ///
         /// Null if the PDB doesn't contain Source Server data.
         /// </param>
         /// <param name="size">Size of the data in bytes.</param>
         /// <remarks>
-        /// This method is a replacement for <see cref="M:ISymUnmanagedSourceServerModule.GetSourceServerData"/>. 
-        /// The reader doesn't implement <see cref="M:ISymUnmanagedSourceServerModule.GetSourceServerData"/> since 
+        /// This method is a replacement for <see cref="M:ISymUnmanagedSourceServerModule.GetSourceServerData"/>.
+        /// The reader doesn't implement <see cref="M:ISymUnmanagedSourceServerModule.GetSourceServerData"/> since
         /// the format of the returned data is completely different for Portable PDBs, which the callers wouldn't expect.
-        /// The native diasymreader may implement <see cref="GetSourceServerData(out byte*, out int)"/> by simply calling 
-        /// to <see cref="M:ISymUnmanagedSourceServerModule.GetSourceServerData"/>. 
+        /// The native diasymreader may implement <see cref="GetSourceServerData(out byte*, out int)"/> by simply calling
+        /// to <see cref="M:ISymUnmanagedSourceServerModule.GetSourceServerData"/>.
         /// </remarks>
         [PreserveSig]
         unsafe int GetSourceServerData(out byte* data, out int size);

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader5.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader5.cs
@@ -4,16 +4,20 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
+
+#if NETSTANDARD2_0
+using IStream = System.Runtime.InteropServices.ComTypes.IStream;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("6576c987-7e8d-4298-a6e1-6f9783165f07")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedReader5 : ISymUnmanagedReader4
+    [GeneratedWhenPossibleComInterface]
+    public unsafe partial interface ISymUnmanagedReader5 : ISymUnmanagedReader4
     {
+#if NETSTANDARD2_0
         #region ISymUnmanagedReader methods
 
         [PreserveSig]
@@ -210,6 +214,7 @@ namespace Microsoft.DiaSymReader
         new unsafe int GetSourceServerData(out byte* data, out int size);
 
         #endregion
+#endif
 
         #region ISymUnmanagedReader5 methods
 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader5.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader5.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DiaSymReader
     [GeneratedWhenPossibleComInterface]
     public unsafe partial interface ISymUnmanagedReader5 : ISymUnmanagedReader4
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
         #region ISymUnmanagedReader methods
 
@@ -144,7 +146,7 @@ namespace Microsoft.DiaSymReader
         #region ISymUnmanagedReader3 methods
 
         /// <summary>
-        /// Gets a custom debug information based upon its name and an EnC 1-based version number. 
+        /// Gets a custom debug information based upon its name and an EnC 1-based version number.
         /// </summary>
         [PreserveSig]
         new int GetSymAttributeByVersion(
@@ -156,7 +158,7 @@ namespace Microsoft.DiaSymReader
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] customDebugInformation);
 
         /// <summary>
-        /// Gets a custom debug information based upon its name and an EnC 1-based version number. 
+        /// Gets a custom debug information based upon its name and an EnC 1-based version number.
         /// </summary>
         [PreserveSig]
         new int GetSymAttributeByVersionPreRemap(
@@ -181,9 +183,9 @@ namespace Microsoft.DiaSymReader
         /// Returns a pointer to Portable Debug Metadata. Only available for Portable PDBs.
         /// </summary>
         /// <param name="metadata">
-        /// A pointer to memory where Portable Debug Metadata start. The memory is owned by the SymReader and 
-        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked. 
-        /// 
+        /// A pointer to memory where Portable Debug Metadata start. The memory is owned by the SymReader and
+        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked.
+        ///
         /// Null if the PDB is not portable.
         /// </param>
         /// <param name="size">Size of the metadata block.</param>
@@ -191,7 +193,7 @@ namespace Microsoft.DiaSymReader
         /// S_OK if the PDB is portable, S_FALSE if it isn't.
         /// </returns>
         /// <remarks>
-        /// If the store was updated via <see cref="UpdateSymbolStore(string, IStream)"/> 
+        /// If the store was updated via <see cref="UpdateSymbolStore(string, IStream)"/>
         /// returns the metadata of the latest update.
         /// </remarks>
         [PreserveSig]
@@ -201,9 +203,9 @@ namespace Microsoft.DiaSymReader
         /// Returns a pointer to Source Server data stored in the PDB.
         /// </summary>
         /// <param name="data">
-        /// A pointer to memory where Source Server data start. The memory is owned by the SymReader and 
-        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked. 
-        /// 
+        /// A pointer to memory where Source Server data start. The memory is owned by the SymReader and
+        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked.
+        ///
         /// Null if the PDB doesn't contain Source Server data.
         /// </param>
         /// <param name="size">Size of the data in bytes.</param>
@@ -225,9 +227,9 @@ namespace Microsoft.DiaSymReader
         /// EnC 1-based version number. Version 1 corresponds to the baseline.
         /// </param>
         /// <param name="metadata">
-        /// A pointer to memory where Portable Debug Metadata start. The memory is owned by the SymReader and 
-        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked. 
-        /// 
+        /// A pointer to memory where Portable Debug Metadata start. The memory is owned by the SymReader and
+        /// valid until <see cref="ISymUnmanagedDispose.Destroy"/> is invoked.
+        ///
         /// Null if the PDB is not portable.
         /// </param>
         /// <param name="size">Size of the metadata block.</param>

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader6.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedReader6.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("2d7babeb-4415-4a19-8be0-dfacc7611594")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedCompilerInfoReader
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedCompilerInfoReader
     {
         /// <summary>
         /// Returns compiler version number and name.

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedScope.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedScope.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("68005D0F-B8E0-3B01-84D5-A11A94154942")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedScope
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedScope
     {
         [PreserveSig]
         int GetMethod([MarshalAs(UnmanagedType.Interface)] out ISymUnmanagedMethod method);

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedScope2.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedScope2.cs
@@ -7,12 +7,12 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComVisible(false)]
     [Guid("AE932FBA-3FD8-4dba-8232-30A2309B02DB")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [ComImport]
-    public interface ISymUnmanagedScope2 : ISymUnmanagedScope
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedScope2 : ISymUnmanagedScope
     {
+#if NETSTANDARD2_0
         #region ISymUnmanagedScope methods 
 
         [PreserveSig]
@@ -49,6 +49,7 @@ namespace Microsoft.DiaSymReader
             [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] ISymUnmanagedNamespace[] namespaces);
 
         #endregion
+#endif
 
         #region ISymUnmanagedScope2 methods
 

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedScope2.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedScope2.cs
@@ -12,8 +12,10 @@ namespace Microsoft.DiaSymReader
     [GeneratedWhenPossibleComInterface]
     public partial interface ISymUnmanagedScope2 : ISymUnmanagedScope
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
-        #region ISymUnmanagedScope methods 
+        #region ISymUnmanagedScope methods
 
         [PreserveSig]
         new int GetMethod([MarshalAs(UnmanagedType.Interface)] out ISymUnmanagedMethod method);

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedSourceServerModule.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedSourceServerModule.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("997DD0CC-A76F-4c82-8D79-EA87559D27AD")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedSourceServerModule
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedSourceServerModule
     {
         /// <summary>
         /// Returns the source server data for the module.

--- a/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedVariable.cs
+++ b/src/Microsoft.DiaSymReader/Reader/ISymUnmanagedVariable.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("9F60EEBE-2D9A-3F7C-BF58-80BC991C60BB")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedVariable
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedVariable
     {
         [PreserveSig]
         int GetName(

--- a/src/Microsoft.DiaSymReader/SymUnmanagedFactory.cs
+++ b/src/Microsoft.DiaSymReader/SymUnmanagedFactory.cs
@@ -77,22 +77,22 @@ namespace Microsoft.DiaSymReader
 
 
 #if NETSTANDARD2_0
-        [DllImport("kernel32")]
-        private static extern IntPtr LoadLibrary(string path);
+        [DllImport("kernel32", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern IntPtr LoadLibraryW(string path);
 #else
         [LibraryImport("kernel32", StringMarshalling = StringMarshalling.Utf16)]
-        private static partial IntPtr LoadLibrary(string path);
+        private static partial IntPtr LoadLibraryW(string path);
 #endif
 
-        [DllImport("kernel32")]
+        [DllImport("kernel32", ExactSpelling = true)]
         private static extern bool FreeLibrary(IntPtr hModule);
 
 #if NETSTANDARD2_0
-        [DllImport("kernel32")]
-        private static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
+        [DllImport("kernel32", ExactSpelling = true)]
+        private static extern IntPtr GetProcAddress(IntPtr hModule, [MarshalAs(UnmanagedType.LPStr)] string procedureName);
 #else
-        [LibraryImport("kernel32", StringMarshalling = StringMarshalling.Utf16)]
-        private static partial IntPtr GetProcAddress(IntPtr hModule, string procedureName);
+        [LibraryImport("kernel32")]
+        private static partial IntPtr GetProcAddress(IntPtr hModule, [MarshalAs(UnmanagedType.LPStr)] string procedureName);
 #endif
 
 #if NETSTANDARD2_0
@@ -120,7 +120,7 @@ namespace Microsoft.DiaSymReader
                 return null;
             }
 
-            var moduleHandle = LoadLibrary(Path.Combine(dir, DiaSymReaderModuleName));
+            var moduleHandle = LoadLibraryW(Path.Combine(dir, DiaSymReaderModuleName));
             if (moduleHandle == IntPtr.Zero)
             {
                 Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());

--- a/src/Microsoft.DiaSymReader/Utilities/ComMemoryStream.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/ComMemoryStream.cs
@@ -5,9 +5,14 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
-using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.InteropServices;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
+
+#if NETSTANDARD2_0
 using STATSTG = System.Runtime.InteropServices.ComTypes.STATSTG;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
@@ -18,7 +23,10 @@ namespace Microsoft.DiaSymReader
     /// 2. Read and Write are optimized to avoid copying (see <see cref="IUnsafeComStream"/>)
     /// 3. Allocates in chunks instead of a contiguous buffer to avoid re-alloc and copy costs when growing.
     /// </summary>
-    internal unsafe sealed class ComMemoryStream : IUnsafeComStream
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    internal unsafe sealed partial class ComMemoryStream : IUnsafeComStream
     {
         // internal for testing
         internal const int STREAM_SEEK_SET = 0;
@@ -240,12 +248,12 @@ namespace Microsoft.DiaSymReader
         {
         }
 
-        void IUnsafeComStream.Clone(out IStream ppstm)
+        void IUnsafeComStream.Clone(out IntPtr ppstm)
         {
             throw new NotSupportedException();
         }
 
-        void IUnsafeComStream.CopyTo(IStream pstm, long cb, int* pcbRead, int* pcbWritten)
+        void IUnsafeComStream.CopyTo(IntPtr pstm, long cb, int* pcbRead, int* pcbWritten)
         {
             throw new NotSupportedException();
         }

--- a/src/Microsoft.DiaSymReader/Utilities/ComStreamWrapper.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/ComStreamWrapper.cs
@@ -5,11 +5,22 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.InteropServices;
+
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
+
+#if NETSTANDARD2_0
+using STATSTG = System.Runtime.InteropServices.ComTypes.STATSTG;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
-    internal sealed class ComStreamWrapper : IStream
+#if NET9_0_OR_GREATER
+    [GeneratedComClass]
+#endif
+    internal unsafe sealed partial class ComStreamWrapper : IUnsafeComStream, System.Runtime.InteropServices.ComTypes.IStream
     {
         private readonly Stream _stream;
 
@@ -19,11 +30,6 @@ namespace Microsoft.DiaSymReader
             Debug.Assert(stream.CanSeek);
 
             _stream = stream;
-        }
-
-        public void Commit(int grfCommitFlags)
-        {
-            _stream.Flush();
         }
 
         /// <summary>
@@ -66,29 +72,106 @@ namespace Microsoft.DiaSymReader
         /// The actual number of bytes read can be fewer than the number of bytes requested 
         /// if an error occurs or if the end of the stream is reached during the read operation.
         /// </summary>
-        public unsafe void Read(byte[] pv, int cb, IntPtr pcbRead)
+        public unsafe void Read(byte* pv, int cb, int* pcbRead)
         {
-            int bytesRead = TryReadAll(_stream, pv, 0, cb);
+            var buffer = new byte[cb]; 
+            int bytesRead = TryReadAll(_stream, buffer, 0, cb);
 
-            if (pcbRead != IntPtr.Zero)
+            for (int i = 0; i < bytesRead; ++i)
             {
-                *(int*)pcbRead = bytesRead;
+                pv[i] = buffer[i];
+            }
+
+            if (pcbRead != null)
+            {
+                *pcbRead = bytesRead;
             }
         }
 
-        public unsafe void Seek(long dlibMove, int origin, IntPtr plibNewPosition)
+        void System.Runtime.InteropServices.ComTypes.IStream.Read(byte[] pv, int cb, nint pcbRead)
+        {
+            fixed (byte* p = pv)
+            {
+                Read(p, cb, (int*)pcbRead);
+            }
+        }
+
+        public unsafe void Seek(long dlibMove, int origin, long* plibNewPosition)
         {
             long newPosition = _stream.Seek(dlibMove, (SeekOrigin)origin);
-            if (plibNewPosition != IntPtr.Zero)
+            if (plibNewPosition != null)
             {
-                *(long*)plibNewPosition = newPosition;
+                *plibNewPosition = newPosition;
             }
         }
 
-        public void SetSize(long libNewSize)
+        void System.Runtime.InteropServices.ComTypes.IStream.Seek(long dlibMove, int dwOrigin, nint plibNewPosition)
+            => Seek(dlibMove, dwOrigin, (long*)plibNewPosition);
+
+        public unsafe void Write(byte* pv, int cb, int* pcbWritten)
         {
-            _stream.SetLength(libNewSize);
+            var buffer = new byte[cb];
+            for (int i = 0; i < cb; ++i)
+            {
+                buffer[i] = pv[i];
+            }
+
+            _stream.Write(buffer, 0, cb);
+            if (pcbWritten != null)
+            {
+                *pcbWritten = cb;
+            }
         }
+
+        void System.Runtime.InteropServices.ComTypes.IStream.Write(byte[] pv, int cb, nint pcbWritten)
+        {
+            fixed (byte* p = pv)
+            {
+                Write(p, cb, (int*)pcbWritten);
+            }
+        }
+
+        public void Clone(out IntPtr ppstm)
+            => throw new NotSupportedException();
+
+        void System.Runtime.InteropServices.ComTypes.IStream.Clone(out System.Runtime.InteropServices.ComTypes.IStream ppstm)
+            => throw new NotSupportedException();
+
+        public void Commit(int grfCommitFlags)
+            => _stream.Flush();
+
+        void System.Runtime.InteropServices.ComTypes.IStream.Commit(int grfCommitFlags)
+            => Commit(grfCommitFlags);
+
+        public void CopyTo(IntPtr pstm, long cb, int* pcbRead, int* pcbWritten)
+            => throw new NotSupportedException();
+
+        void System.Runtime.InteropServices.ComTypes.IStream.CopyTo(System.Runtime.InteropServices.ComTypes.IStream pstm, long cb, nint pcbRead, nint pcbWritten)
+            => throw new NotSupportedException();
+
+        public void LockRegion(long libOffset, long cb, int lockType)
+            => throw new NotSupportedException();
+
+        void System.Runtime.InteropServices.ComTypes.IStream.LockRegion(long libOffset, long cb, int dwLockType)
+            => throw new NotSupportedException();
+
+        public void UnlockRegion(long libOffset, long cb, int lockType)
+            => throw new NotSupportedException();
+
+        void System.Runtime.InteropServices.ComTypes.IStream.UnlockRegion(long libOffset, long cb, int dwLockType)
+            => throw new NotSupportedException();
+
+        public void Revert()
+            => throw new NotSupportedException();
+
+        void System.Runtime.InteropServices.ComTypes.IStream.Revert()
+            => throw new NotSupportedException();
+
+        public void SetSize(long libNewSize)
+            => _stream.SetLength(libNewSize);
+
+        void System.Runtime.InteropServices.ComTypes.IStream.SetSize(long libNewSize)
+            => SetSize(libNewSize);
 
         public void Stat(out STATSTG pstatstg, int grfStatFlag)
         {
@@ -98,38 +181,40 @@ namespace Microsoft.DiaSymReader
             };
         }
 
-        public unsafe void Write(byte[] pv, int cb, IntPtr pcbWritten)
+        void System.Runtime.InteropServices.ComTypes.IStream.Stat(out System.Runtime.InteropServices.ComTypes.STATSTG pstatstg, int grfStatFlag)
         {
-            _stream.Write(pv, 0, cb);
-            if (pcbWritten != IntPtr.Zero)
+            pstatstg = new System.Runtime.InteropServices.ComTypes.STATSTG()
             {
-                *(int*)pcbWritten = cb;
+                cbSize = _stream.Length
+            };
+        }
+
+#if NET9_0_OR_GREATER
+        [CustomMarshaller(typeof(System.Runtime.InteropServices.ComTypes.IStream), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
+        [CustomMarshaller(typeof(System.Runtime.InteropServices.ComTypes.IStream), MarshalMode.UnmanagedToManagedIn, typeof(Marshaller))]
+        public static class Marshaller
+        {
+            public static IntPtr ConvertToUnmanaged(System.Runtime.InteropServices.ComTypes.IStream stream)
+            {
+                if (stream is IUnsafeComStream unsafeComStream)
+                {
+                    return (IntPtr)ComInterfaceMarshaller<IUnsafeComStream>.ConvertToUnmanaged(unsafeComStream);
+                }
+
+                throw new NotSupportedException("IStream implementation cannot be marshalled");
+            }
+
+            public static System.Runtime.InteropServices.ComTypes.IStream ConvertToManaged(IntPtr s)
+                => throw new NotSupportedException("IStream cannot be marshalled to managed");
+
+            public static void Free(IntPtr unmanaged)
+            {
+                if (unmanaged != default)
+                {
+                    Marshal.Release(unmanaged);
+                }
             }
         }
-
-        public void Clone(out IStream ppstm)
-        {
-            throw new NotSupportedException();
-        }
-
-        public void CopyTo(IStream pstm, long cb, IntPtr pcbRead, IntPtr pcbWritten)
-        {
-            throw new NotSupportedException();
-        }
-
-        public void LockRegion(long libOffset, long cb, int lockType)
-        {
-            throw new NotSupportedException();
-        }
-
-        public void Revert()
-        {
-            throw new NotSupportedException();
-        }
-
-        public void UnlockRegion(long libOffset, long cb, int lockType)
-        {
-            throw new NotSupportedException();
-        }
+#endif
     }
 }

--- a/src/Microsoft.DiaSymReader/Utilities/ComStreamWrapper.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/ComStreamWrapper.cs
@@ -69,12 +69,12 @@ namespace Microsoft.DiaSymReader
         }
 
         /// <summary>
-        /// The actual number of bytes read can be fewer than the number of bytes requested 
+        /// The actual number of bytes read can be fewer than the number of bytes requested
         /// if an error occurs or if the end of the stream is reached during the read operation.
         /// </summary>
         public unsafe void Read(byte* pv, int cb, int* pcbRead)
         {
-            var buffer = new byte[cb]; 
+            var buffer = new byte[cb];
             int bytesRead = TryReadAll(_stream, buffer, 0, cb);
 
             for (int i = 0; i < bytesRead; ++i)
@@ -196,7 +196,11 @@ namespace Microsoft.DiaSymReader
         {
             public static IntPtr ConvertToUnmanaged(System.Runtime.InteropServices.ComTypes.IStream stream)
             {
-                if (stream is IUnsafeComStream unsafeComStream)
+                if (stream is null)
+                {
+                    return IntPtr.Zero;
+                }
+                else if (stream is IUnsafeComStream unsafeComStream)
                 {
                     return (IntPtr)ComInterfaceMarshaller<IUnsafeComStream>.ConvertToUnmanaged(unsafeComStream);
                 }
@@ -209,7 +213,7 @@ namespace Microsoft.DiaSymReader
 
             public static void Free(IntPtr unmanaged)
             {
-                if (unmanaged != default)
+                if (unmanaged != IntPtr.Zero)
                 {
                     Marshal.Release(unmanaged);
                 }

--- a/src/Microsoft.DiaSymReader/Utilities/IUnsafeComStream.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/IUnsafeComStream.cs
@@ -3,9 +3,16 @@
 // See the License.txt file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
+
+#if NETSTANDARD2_0
 using STATSTG = System.Runtime.InteropServices.ComTypes.STATSTG;
+#endif
 
 namespace Microsoft.DiaSymReader
 {
@@ -14,8 +21,9 @@ namespace Microsoft.DiaSymReader
     /// the Read and Write methods take an <see cref="IntPtr"/> instead of a byte[] to avoid the
     /// allocation cost when called from native code.
     /// </summary>
-    [Guid("0000000c-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), ComImport]
-    internal unsafe interface IUnsafeComStream
+    [Guid("0000000c-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [GeneratedWhenPossibleComInterface]
+    internal unsafe partial interface IUnsafeComStream
     {
         // ISequentialStream portion
         void Read(byte* pv, int cb, int* pcbRead);
@@ -24,12 +32,90 @@ namespace Microsoft.DiaSymReader
         // IStream portion
         void Seek(long dlibMove, int dwOrigin, long* plibNewPosition);
         void SetSize(long libNewSize);
-        void CopyTo(IStream pstm, long cb, int* pcbRead, int* pcbWritten);
+        void CopyTo(IntPtr pstm, long cb, int* pcbRead, int* pcbWritten);
         void Commit(int grfCommitFlags);
         void Revert();
         void LockRegion(long libOffset, long cb, int dwLockType);
         void UnlockRegion(long libOffset, long cb, int dwLockType);
         void Stat(out STATSTG pstatstg, int grfStatFlag);
-        void Clone(out IStream ppstm);
+        void Clone(out IntPtr ppstm);
     }
+
+#if NET9_0_OR_GREATER
+    [NativeMarshalling(typeof(STASTGMarshaller))]
+    public struct STATSTG
+    {
+        public string pwcsName;
+        public int type;
+        public long cbSize;
+        public FILETIME mtime;
+        public FILETIME ctime;
+        public FILETIME atime;
+        public int grfMode;
+        public int grfLocksSupported;
+        public Guid clsid;
+        public int grfStateBits;
+        public int reserved;
+    }
+
+    [CustomMarshaller(typeof(STATSTG), MarshalMode.ManagedToUnmanagedOut, typeof(STASTGMarshaller))]
+    [CustomMarshaller(typeof(STATSTG), MarshalMode.UnmanagedToManagedOut, typeof(STASTGMarshaller))]
+    public static unsafe class STASTGMarshaller
+    {
+        public struct Native
+        {
+            public ushort* pwcsName;
+            public int type;
+            public long cbSize;
+            public FILETIME mtime;
+            public FILETIME ctime;
+            public FILETIME atime;
+            public int grfMode;
+            public Guid clsid;
+            public int grfLocksSupported;
+            public int grfStateBits;
+            public int reserved;
+        }
+
+        public static STATSTG ConvertToManaged(Native n)
+        {
+            string name = null;
+            if (n.pwcsName != null)
+            {
+                name = Utf16StringMarshaller.ConvertToManaged(n.pwcsName);
+                Marshal.FreeCoTaskMem((IntPtr)n.pwcsName);
+            }
+
+            return new()
+            {
+                pwcsName = name,
+                type = n.type,
+                cbSize = n.cbSize,
+                mtime = n.mtime,
+                ctime = n.ctime,
+                atime = n.atime,
+                grfMode = n.grfMode,
+                clsid = n.clsid,
+                grfLocksSupported = n.grfLocksSupported,
+                grfStateBits = n.grfStateBits,
+                reserved = n.reserved
+            };
+        }
+
+        public static Native ConvertToUnmanaged(STATSTG n) => new ()
+            {
+                pwcsName = n.pwcsName is null ? null : Utf16StringMarshaller.ConvertToUnmanaged(n.pwcsName),
+                type = n.type,
+                cbSize = n.cbSize,
+                mtime = n.mtime,
+                ctime = n.ctime,
+                atime = n.atime,
+                grfMode = n.grfMode,
+                clsid = n.clsid,
+                grfLocksSupported = n.grfLocksSupported,
+                grfStateBits = n.grfStateBits,
+                reserved = n.reserved
+            };
+}
+#endif
 }

--- a/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedAsyncMethodPropertiesWriter.cs
+++ b/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedAsyncMethodPropertiesWriter.cs
@@ -10,11 +10,11 @@ using System.Security;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("FC073774-1739-4232-BD56-A027294BEC15")]
     [SuppressUnmanagedCodeSecurity]
-    internal interface ISymUnmanagedAsyncMethodPropertiesWriter
+    [GeneratedWhenPossibleComInterface]
+    internal partial interface ISymUnmanagedAsyncMethodPropertiesWriter
     {
         void DefineKickoffMethod(int kickoffMethod);
         void DefineCatchHandlerILOffset(int catchHandlerOffset);

--- a/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedCompilerInfoWriter.cs
+++ b/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedCompilerInfoWriter.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport]
     [Guid("2ae6a06a-92ba-4c2d-a64e-7e9fa421a330")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [ComVisible(false)]
-    public interface ISymUnmanagedCompilerInfoWriter
+    [GeneratedWhenPossibleComInterface]
+    public partial interface ISymUnmanagedCompilerInfoWriter
     {
         /// <summary>
         /// Adds compiler version number and name.

--- a/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedDocumentWriter.cs
+++ b/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedDocumentWriter.cs
@@ -10,8 +10,9 @@ using System.Security;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("B01FAFEB-C450-3A4D-BEEC-B4CEEC01E006"), SuppressUnmanagedCodeSecurity]
-    internal interface ISymUnmanagedDocumentWriter
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("B01FAFEB-C450-3A4D-BEEC-B4CEEC01E006"), SuppressUnmanagedCodeSecurity]
+    [GeneratedWhenPossibleComInterface]
+    internal partial interface ISymUnmanagedDocumentWriter
     {
         void SetSource(uint sourceSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] byte[] source);
         void SetCheckSum(Guid algorithmId, uint checkSumSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] byte[] checkSum);

--- a/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedWriter.cs
+++ b/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedWriter.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
-#pragma warning disable 436 // SuppressUnmanagedCodeSecurityAttribute defined in source and mscorlib 
+#pragma warning disable 436 // SuppressUnmanagedCodeSecurityAttribute defined in source and mscorlib
 
 using System;
 using System.Runtime.InteropServices;
@@ -101,7 +101,7 @@ namespace Microsoft.DiaSymReader
         #region ISymUnmanagedWriter5
 
         /// <summary>
-        /// Open a special custom data section to emit token to source span mapping information into. 
+        /// Open a special custom data section to emit token to source span mapping information into.
         /// Opening this section while a method is already open or vice versa is an error.
         /// </summary>
         void OpenMapTokensToSourceSpans();
@@ -113,7 +113,7 @@ namespace Microsoft.DiaSymReader
         void CloseMapTokensToSourceSpans();
 
         /// <summary>
-        /// Maps the given metadata token to the given source line span in the specified source file. 
+        /// Maps the given metadata token to the given source line span in the specified source file.
         /// Must be called between calls to <see cref="OpenMapTokensToSourceSpans"/> and <see cref="CloseMapTokensToSourceSpans"/>.
         /// </summary>
         void MapTokenToSourceSpan(int token, ISymUnmanagedDocumentWriter document, int startLine, int startColumn, int endLine, int endColumn);
@@ -132,6 +132,8 @@ namespace Microsoft.DiaSymReader
 #endif
     internal unsafe partial interface ISymUnmanagedWriter8 : ISymUnmanagedWriter5
     {
+        // .NET 8+ COM source generators respect COM interface inheritance
+        // so re-declaration of inherited method is not needed.
 #if NETSTANDARD2_0
         //  ISymUnmanagedWriter, ISymUnmanagedWriter2, ISymUnmanagedWriter3, ISymUnmanagedWriter4, ISymUnmanagedWriter5
         void _VtblGap1_33();
@@ -173,7 +175,7 @@ namespace Microsoft.DiaSymReader
         private readonly long _longValue;
 
         /// <summary>
-        /// This field determines the size of the struct 
+        /// This field determines the size of the struct
         /// (16 bytes on 32-bit platforms, 24 bytes on 64-bit platforms).
         /// </summary>
         [FieldOffset(8)]

--- a/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedWriter.cs
+++ b/src/Microsoft.DiaSymReader/Writer/ISymUnmanagedWriter.cs
@@ -6,12 +6,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
 using System.Security;
 
 namespace Microsoft.DiaSymReader
 {
-    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("98ECEE1E-752D-11d3-8D56-00C04F680B2B"), SuppressUnmanagedCodeSecurity]
-    internal interface IPdbWriter
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("98ECEE1E-752D-11d3-8D56-00C04F680B2B"), SuppressUnmanagedCodeSecurity]
+    [GeneratedWhenPossibleComInterface]
+    internal partial interface IPdbWriter
     {
         int __SetPath(/*[in] const WCHAR* szFullPathName, [in] IStream* pIStream, [in] BOOL fFullBuild*/);
         int __OpenMod(/*[in] const WCHAR* szModuleName, [in] const WCHAR* szFileName*/);
@@ -24,8 +28,13 @@ namespace Microsoft.DiaSymReader
     /// <summary>
     /// The highest version of the interface available on Desktop FX 4.0+.
     /// </summary>
-    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("DCF7780D-BDE9-45DF-ACFE-21731A32000C"), SuppressUnmanagedCodeSecurity]
-    internal unsafe interface ISymUnmanagedWriter5
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("DCF7780D-BDE9-45DF-ACFE-21731A32000C"), SuppressUnmanagedCodeSecurity]
+#if NET9_0_OR_GREATER
+    [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+#else
+    [ComImport]
+#endif
+    internal unsafe partial interface ISymUnmanagedWriter5
     {
         #region ISymUnmanagedWriter
 
@@ -45,8 +54,8 @@ namespace Microsoft.DiaSymReader
         void OpenNamespace(string name);
         void CloseNamespace();
         void UsingNamespace(string fullName);
-        void SetMethodSourceRange(ISymUnmanagedDocumentWriter startDoc, uint startLine, uint startColumn, object endDoc, uint endLine, uint endColumn);
-        void Initialize([MarshalAs(UnmanagedType.IUnknown)] object emitter, string filename, [MarshalAs(UnmanagedType.IUnknown)] object ptrIStream, bool fullBuild);
+        void SetMethodSourceRange(ISymUnmanagedDocumentWriter startDoc, uint startLine, uint startColumn, ISymUnmanagedDocumentWriter endDoc, uint endLine, uint endColumn);
+        void Initialize([MarshalAs(UnmanagedType.Interface)] object emitter, string filename, [MarshalAs(UnmanagedType.Interface)] object ptrIStream, [MarshalAs(UnmanagedType.Bool)] bool fullBuild);
         void GetDebugInfo(ref ImageDebugDirectory debugDirectory, uint dataCount, out uint dataCountPtr, byte* data);
         void DefineSequencePoints(ISymUnmanagedDocumentWriter document, int count,
           [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] int[] offsets,
@@ -55,8 +64,8 @@ namespace Microsoft.DiaSymReader
           [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] int[] endLines,
           [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] int[] endColumns);
         void RemapToken(uint oldToken, uint newToken);
-        void Initialize2([MarshalAs(UnmanagedType.IUnknown)] object emitter, string tempfilename, [MarshalAs(UnmanagedType.IUnknown)] object ptrIStream, bool fullBuild, string finalfilename);
-        void DefineConstant(string name, object value, uint sig, byte* signature);
+        void Initialize2([MarshalAs(UnmanagedType.Interface)] object emitter, string tempfilename, [MarshalAs(UnmanagedType.Interface)] object ptrIStream, [MarshalAs(UnmanagedType.Bool)] bool fullBuild, string finalfilename);
+        void DefineConstant(string name, [MarshalAs(UnmanagedType.Struct)] object value, uint sig, byte* signature);
         void Abort();
 
         #endregion
@@ -115,22 +124,29 @@ namespace Microsoft.DiaSymReader
     /// <summary>
     /// The highest version of the interface available in Microsoft.DiaSymReader.Native.
     /// </summary>
-    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("5ba52f3b-6bf8-40fc-b476-d39c529b331e"), SuppressUnmanagedCodeSecurity]
-    internal interface ISymUnmanagedWriter8 : ISymUnmanagedWriter5
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("5ba52f3b-6bf8-40fc-b476-d39c529b331e"), SuppressUnmanagedCodeSecurity]
+#if NET9_0_OR_GREATER
+    [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+#else
+    [ComImport]
+#endif
+    internal unsafe partial interface ISymUnmanagedWriter8 : ISymUnmanagedWriter5
     {
+#if NETSTANDARD2_0
         //  ISymUnmanagedWriter, ISymUnmanagedWriter2, ISymUnmanagedWriter3, ISymUnmanagedWriter4, ISymUnmanagedWriter5
         void _VtblGap1_33();
+#endif
 
         // ISymUnmanagedWriter6
-        void InitializeDeterministic([MarshalAs(UnmanagedType.IUnknown)] object emitter, [MarshalAs(UnmanagedType.IUnknown)] object stream);
+        void InitializeDeterministic([MarshalAs(UnmanagedType.Interface)] object emitter, [MarshalAs(UnmanagedType.Interface)] object stream);
 
         // ISymUnmanagedWriter7
-        unsafe void UpdateSignatureByHashingContent([In]byte* buffer, int size);
+        unsafe void UpdateSignatureByHashingContent(byte* buffer, int size);
 
         // ISymUnmanagedWriter8
         void UpdateSignature(Guid pdbId, uint stamp, int age);
-        unsafe void SetSourceServerData([In]byte* data, int size);
-        unsafe void SetSourceLinkData([In]byte* data, int size);
+        unsafe void SetSourceServerData(byte* data, int size);
+        unsafe void SetSourceLinkData(byte* data, int size);
     }
 
     /// <summary>
@@ -188,7 +204,7 @@ namespace Microsoft.DiaSymReader
         public readonly byte* Data3;
     }
 
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential)]
     internal struct ImageDebugDirectory
     {
         internal int Characteristics;


### PR DESCRIPTION
For .NET 9 TFM, use the COM source generator
which supports cross-platform COM interop via
the [`ComWrappers`](https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.comwrappers) API.