### PR TITLE
Update source-build team references

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,4 +1,4 @@
-﻿<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+﻿<!-- When altering this file, please include @dotnet/product-construction as a reviewer. -->
 
 <Project>
   <PropertyGroup>


### PR DESCRIPTION
The source-build-internal team is being deprecated. All references to it were updated.

Related to https://github.com/dotnet/source-build/issues/4645