### PR TITLE
Target NetCurrent property

### DIFF
--- a/src/Microsoft.DiaSymReader/Microsoft.DiaSymReader.csproj
+++ b/src/Microsoft.DiaSymReader/Microsoft.DiaSymReader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;$(NetCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
The `NetCurrent` property should be used to always target the TFM defined by Arcade.

This was found as part of the work on https://github.com/dotnet/sdk/pull/45435.