### PR TITLE
Enable AOT and platform compatibility analyzers.

### DIFF
--- a/src/Microsoft.DiaSymReader/Microsoft.DiaSymReader.csproj
+++ b/src/Microsoft.DiaSymReader/Microsoft.DiaSymReader.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(NetCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -7,6 +7,7 @@
     <Description>Microsoft DiaSymReader interop interfaces and utilities.</Description>
     <PackageReleaseNotes>Microsoft DiaSymReader interop interfaces and utilities</PackageReleaseNotes>
     <PackageTags>DiaSymReader ISymUnmanagedReader PDB COM interop debugging</PackageTags>
+    <IsAotCompatible Condition="'$(TargetFramework)' == '$(NetCurrent)'">true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.DiaSymReader.PortablePdb" />

--- a/src/Microsoft.DiaSymReader/Reader/SymUnmanagedReaderFactory.cs
+++ b/src/Microsoft.DiaSymReader/Reader/SymUnmanagedReaderFactory.cs
@@ -8,6 +8,9 @@ using System.IO;
 
 namespace Microsoft.DiaSymReader
 {
+#if NET
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
     public static class SymUnmanagedReaderFactory
     {
         /// <summary>

--- a/src/Microsoft.DiaSymReader/SymUnmanagedFactory.cs
+++ b/src/Microsoft.DiaSymReader/SymUnmanagedFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -21,6 +21,9 @@ using System.Runtime.InteropServices.Marshalling;
 
 namespace Microsoft.DiaSymReader
 {
+#if NET
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
     internal static partial class SymUnmanagedFactory
     {
         private const string AlternativeLoadPathEnvironmentVariableName = "MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH";

--- a/src/Microsoft.DiaSymReader/Writer/SymUnmanagedWriterFactory.cs
+++ b/src/Microsoft.DiaSymReader/Writer/SymUnmanagedWriterFactory.cs
@@ -7,6 +7,9 @@ using System.Diagnostics;
 
 namespace Microsoft.DiaSymReader
 {
+#if NET
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
     public static class SymUnmanagedWriterFactory
     {
         /// <summary>


### PR DESCRIPTION
* The `SymUnmanaged***Factory` APIs are marked as supported on Windows only.
* The AOT compatibility analyzer was enabled. There was a warning in the COM registry activation path, which was rewritten to use `ComWrappers`.
  * It is not covered by tests at the moment because of known issues, but after tweaking the test I was able to validate it on my machine (activation succeeded but it subsequently failed because it found a very old `diasymreader.dll`).