### PR TITLE
Change casing of file reference

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ extends:
         enabled: true
       tsa:
         enabled: true
-        configFile: '$(Build.SourcesDirectory)/eng/TSAConfig.gdntsa'
+        configFile: '$(Build.SourcesDirectory)/eng/tsaconfig.gdntsa'
     pool:
       name: AzurePipelines-EO
       image: AzurePipelinesWindows2022compliantGPT


### PR DESCRIPTION
Change casing of file reference

ISSUE:
As much as the content in the yml file that makes that section sound like it runs on Windows, it has a case sensitive file path.  This means that the reference to the file fails, and therefore the TSA settings aren't recognized.

FIX:
Change the casing of the file reference to match the actual file name casing.  Alternative fix would be to rename the file.