### PR TITLE
Fix crash in UnsafeComStreamWrapper.Stat with in-memory symbols

### DIFF
--- a/src/Microsoft.DiaSymReader/Utilities/ComMemoryStream.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/ComMemoryStream.cs
@@ -203,12 +203,10 @@ namespace Microsoft.DiaSymReader
             _length = (int)libNewSize;
         }
 
-        void IUnsafeComStream.Stat(out STATSTG pstatstg, int grfStatFlag)
+        void IUnsafeComStream.Stat(ref NativeSTATSTG pstatstg, int grfStatFlag)
         {
-            pstatstg = new STATSTG()
-            {
-                cbSize = _length
-            };
+            pstatstg = default;
+            pstatstg.cbSize = _length;
         }
 
         unsafe void IUnsafeComStream.Write(byte* pv, int cb, int* pcbWritten)

--- a/src/Microsoft.DiaSymReader/Utilities/ComStreamWrapper.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/ComStreamWrapper.cs
@@ -174,12 +174,10 @@ namespace Microsoft.DiaSymReader
         void System.Runtime.InteropServices.ComTypes.IStream.SetSize(long libNewSize)
             => SetSize(libNewSize);
 
-        public void Stat(out STATSTG pstatstg, int grfStatFlag)
+        public void Stat(ref NativeSTATSTG pstatstg, int grfStatFlag)
         {
-            pstatstg = new STATSTG()
-            {
-                cbSize = _stream.Length
-            };
+            pstatstg = default;
+            pstatstg.cbSize = _stream.Length;
         }
 
         void System.Runtime.InteropServices.ComTypes.IStream.Stat(out System.Runtime.InteropServices.ComTypes.STATSTG pstatstg, int grfStatFlag)

--- a/src/Microsoft.DiaSymReader/Utilities/IUnsafeComStream.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/IUnsafeComStream.cs
@@ -51,8 +51,8 @@ namespace Microsoft.DiaSymReader
         public FILETIME ctime;
         public FILETIME atime;
         public int grfMode;
-        public Guid clsid;
         public int grfLocksSupported;
+        public Guid clsid;
         public int grfStateBits;
         public int reserved;
     }

--- a/src/Microsoft.DiaSymReader/Utilities/IUnsafeComStream.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/IUnsafeComStream.cs
@@ -10,10 +10,6 @@ using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
-#if NETSTANDARD2_0
-using STATSTG = System.Runtime.InteropServices.ComTypes.STATSTG;
-#endif
-
 namespace Microsoft.DiaSymReader
 {
     /// <summary>
@@ -37,85 +33,27 @@ namespace Microsoft.DiaSymReader
         void Revert();
         void LockRegion(long libOffset, long cb, int dwLockType);
         void UnlockRegion(long libOffset, long cb, int dwLockType);
-        void Stat(out STATSTG pstatstg, int grfStatFlag);
+        void Stat(ref NativeSTATSTG pstatstg, int grfStatFlag);
         void Clone(out IntPtr ppstm);
     }
 
-#if NET9_0_OR_GREATER
-    [NativeMarshalling(typeof(STATSTGMarshaller))]
-    public struct STATSTG
+    /// <summary>
+    /// Native definition of `STATSTG`. Needed because the implementation of <see cref="IUnsafeComStream.Stat" /> in mscordbi 
+    /// (see https://github.com/dotnet/runtime/blob/87523393fdb14746ceb529ab308f11047819fd01/src/coreclr/inc/memorystreams.h#L115) doesn't 
+    /// zero-initialize the structure, so normal marshaling would corrupt the heap trying to process unitialized memory for (e.g. <see cref="STATSTG.pwcsName"/>).
+    /// </summary>
+    internal struct NativeSTATSTG
     {
-        public string pwcsName;
+        public IntPtr pwcsName;
         public int type;
         public long cbSize;
         public FILETIME mtime;
         public FILETIME ctime;
         public FILETIME atime;
         public int grfMode;
-        public int grfLocksSupported;
         public Guid clsid;
+        public int grfLocksSupported;
         public int grfStateBits;
         public int reserved;
     }
-
-    [CustomMarshaller(typeof(STATSTG), MarshalMode.ManagedToUnmanagedOut, typeof(STATSTGMarshaller))]
-    [CustomMarshaller(typeof(STATSTG), MarshalMode.UnmanagedToManagedOut, typeof(STATSTGMarshaller))]
-    public static unsafe class STATSTGMarshaller
-    {
-        public struct Native
-        {
-            public ushort* pwcsName;
-            public int type;
-            public long cbSize;
-            public FILETIME mtime;
-            public FILETIME ctime;
-            public FILETIME atime;
-            public int grfMode;
-            public Guid clsid;
-            public int grfLocksSupported;
-            public int grfStateBits;
-            public int reserved;
-        }
-
-        public static STATSTG ConvertToManaged(Native n)
-        {
-            string name = null;
-            if (n.pwcsName != null)
-            {
-                name = Utf16StringMarshaller.ConvertToManaged(n.pwcsName);
-                Marshal.FreeCoTaskMem((IntPtr)n.pwcsName);
-            }
-
-            return new()
-            {
-                pwcsName = name,
-                type = n.type,
-                cbSize = n.cbSize,
-                mtime = n.mtime,
-                ctime = n.ctime,
-                atime = n.atime,
-                grfMode = n.grfMode,
-                clsid = n.clsid,
-                grfLocksSupported = n.grfLocksSupported,
-                grfStateBits = n.grfStateBits,
-                reserved = n.reserved
-            };
-        }
-
-        public static Native ConvertToUnmanaged(STATSTG n) => new ()
-            {
-                pwcsName = n.pwcsName is null ? null : Utf16StringMarshaller.ConvertToUnmanaged(n.pwcsName),
-                type = n.type,
-                cbSize = n.cbSize,
-                mtime = n.mtime,
-                ctime = n.ctime,
-                atime = n.atime,
-                grfMode = n.grfMode,
-                clsid = n.clsid,
-                grfLocksSupported = n.grfLocksSupported,
-                grfStateBits = n.grfStateBits,
-                reserved = n.reserved
-            };
-}
-#endif
 }

--- a/src/Microsoft.DiaSymReader/Utilities/IUnsafeComStream.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/IUnsafeComStream.cs
@@ -42,6 +42,7 @@ namespace Microsoft.DiaSymReader
     /// (see https://github.com/dotnet/runtime/blob/87523393fdb14746ceb529ab308f11047819fd01/src/coreclr/inc/memorystreams.h#L115) doesn't 
     /// zero-initialize the structure, so normal marshaling would corrupt the heap trying to process unitialized memory for (e.g. <see cref="STATSTG.pwcsName"/>).
     /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     internal struct NativeSTATSTG
     {
         public IntPtr pwcsName;

--- a/src/Microsoft.DiaSymReader/Utilities/UnsafeComStreamWrapper.cs
+++ b/src/Microsoft.DiaSymReader/Utilities/UnsafeComStreamWrapper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 
 #if NET9_0_OR_GREATER
@@ -53,7 +54,7 @@ internal partial class UnsafeComStreamWrapper : IUnsafeComStream, IStream
 
     public void UnlockRegion(long libOffset, long cb, int dwLockType) => _stream.UnlockRegion(libOffset, cb, dwLockType);
 
-    public void Stat(out STATSTG pstatstg, int grfStatFlag) => _stream.Stat(out pstatstg, grfStatFlag);
+    public unsafe void Stat(ref NativeSTATSTG pstatstg, int grfStatFlag) => _stream.Stat(ref pstatstg, grfStatFlag);
 
     public void Clone(out IntPtr ppstm) => _stream.Clone(out ppstm);
 
@@ -85,11 +86,12 @@ internal partial class UnsafeComStreamWrapper : IUnsafeComStream, IStream
 
     void System.Runtime.InteropServices.ComTypes.IStream.Stat(out System.Runtime.InteropServices.ComTypes.STATSTG pstatstg, int grfStatFlag)
     {
-        _stream.Stat(out var unsafeSTASTG, grfStatFlag);
+        NativeSTATSTG nativeStat = default;
+        _stream.Stat(ref nativeStat, grfStatFlag | 1 /* STATFLAG_NONAME */);
 
         pstatstg = new System.Runtime.InteropServices.ComTypes.STATSTG()
         {
-            cbSize = unsafeSTASTG.cbSize,
+            cbSize = nativeStat.cbSize,
         };
     }
 


### PR DESCRIPTION
The IStream implementation in mscordbi (see https://github.com/dotnet/runtime/blob/87523393fdb14746ceb529ab308f11047819fd01/src/coreclr/inc/memorystreams.h#L115) doesn't fully initialize the output param. This PR changes `UnsafeComStreamWrapper`/`IUnsafeComStream` to change this marshalling to avoid the crash.